### PR TITLE
Upticks the version number to mark the new repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
   #        snyk iac test ./output.yaml
 
   release:
+    #needs:
+    #  test
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.5] - 2024-05-30
+
+### Changed
+
+- New repo created for releasing helm-charts repo via Github Pages (using chart-releaser)
+
 ## [1.7.4] - 2024-05-16
 
 ### Fixed


### PR DESCRIPTION
Also adds (and comments out) the `needs` parameter for the `release` job to stop release from happening if tests fail (in the future, when we enable snyk tests).