### PR TITLE
DEVOPS-2410 add timeZone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.6] - 2024-08-12
+
+### Added
+
+- Added `timeZone` to cronJobs.
+
 ## [1.7.5] - 2024-05-30
 
 ### Changed

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.7.5
+version: 1.7.6
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_cronjob.yaml.tpl
+++ b/charts/common/templates/_cronjob.yaml.tpl
@@ -24,6 +24,7 @@ metadata:
   labels:
     {{- include "common.helper.labels" (dict "global" $global.labels "override" $cronJobDetails.labels) | nindent 4}}
 spec:
+  timeZone: {{ default 	"Etc/UTC" $cronJobDetails.timeZone }}
   suspend: {{ default false $cronJobDetails.disabled }}
   concurrencyPolicy: {{ default "Forbid" $cronJobDetails.concurrencyPolicy }}
   failedJobsHistoryLimit: {{ default 5 $cronJobDetails.failedJobsHistoryLimit }}

--- a/test/expected_output/cronjobs-global-serviceaccount.yaml
+++ b/test/expected_output/cronjobs-global-serviceaccount.yaml
@@ -26,6 +26,7 @@ metadata:
     chartVersion: 1.0.0
     team: cool-team
 spec:
+  timeZone: Etc/UTC
   suspend: false
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 5

--- a/test/expected_output/cronjobs.yaml
+++ b/test/expected_output/cronjobs.yaml
@@ -15,6 +15,7 @@ metadata:
     team: cool-team
     testOverrideLabel: hello-override-world
 spec:
+  timeZone: Etc/UTC
   suspend: false
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 5

--- a/test/expected_output/microservice.yaml
+++ b/test/expected_output/microservice.yaml
@@ -311,6 +311,7 @@ metadata:
     chartVersion: 1.0.0
     team: cool-team
 spec:
+  timeZone: Etc/UTC
   suspend: false
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 5

--- a/test/fixtures/Chart.lock
+++ b/test/fixtures/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.7.5
-digest: sha256:0e5277643130fbc2f8759cfeffe06aa161fa4503b70c540157460e4b09f06878
-generated: "2024-05-30T12:24:20.956466-05:00"
+  version: 1.7.6
+digest: sha256:7efec400d9b9ce7f634d2c39211be6d0880026fbbd2ac71bd3b6a56357963376
+generated: "2024-08-12T11:56:34.730722-05:00"

--- a/test/fixtures/Chart.yaml
+++ b/test/fixtures/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.7.5"
+    version: "1.7.6"

--- a/test/fixtures/cronjobs/values-timezone.yaml
+++ b/test/fixtures/cronjobs/values-timezone.yaml
@@ -1,0 +1,31 @@
+global:
+  awsAccountId: "123456789"
+  image: "docker.io/image:abcd1234"
+  annotations:
+    provi.repository: "https://github.com/example/repo"
+    test.annotation: hello-test-world
+  labels:
+    team: cool-team
+
+cronJobs:
+  scheduler:
+    timeZone: "US/Central"
+    schedule: "0 * * * *"
+    annotations:
+      test.override.annotation: hello-override-world
+    labels:
+      testOverrideLabel: hello-override-world
+    pod:
+      containers:
+        schedule:
+          envFrom:
+            - secretRef:
+                name: test-cronjobs
+          command:
+            - date
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 100m
+            limits:
+              memory: 256Mi

--- a/test/test_cronjobs.bats
+++ b/test/test_cronjobs.bats
@@ -80,3 +80,9 @@ teardown() {
 	assert_failure
   assert_output --partial 'You must specify a schedule for cronJob [scheduler]'
 }
+
+# bats test_tags=tag:cronjobs-timezone
+@test "cronjobs: includes timeZone if specified" {
+  run helm template -f test/fixtures/cronjobs/values-timezone.yaml test/fixtures/cronjobs/
+  assert_output --partial 'timeZone: US/Central'
+}


### PR DESCRIPTION
Adds the timeZone key to the CronJob template for the Provi common helm charts templates.

https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones