### PR TITLE
DEVOPS-2414 fix serviceAccount

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,23 @@ on:
       - ci-testing
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Install helm deps
+        run: |
+          helm dependency build "${GITHUB_WORKSPACE}/charts/common"
+
+      - name: Test
+        run: |
+          make test
+
   security:
     runs-on: ubuntu-latest
     container:
@@ -37,8 +54,7 @@ jobs:
           snyk iac test ./output.yaml
 
   release:
-    needs:
-      security
+    needs: [test, security]
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.7] - 2024-08-13
+
+### Fixed
+
+- Fixed a logic error in the serviceaccount template
+- Fixed the `serviceAccount` syntax in the values file for the cronjobs tests and un-skipped a test
+
+### Added
+
+- Added test to the CI job
+
 ## [1.7.6] - 2024-08-12
 
 ### Added

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.7.6
+version: 1.7.7
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_serviceaccount.yaml.tpl
+++ b/charts/common/templates/_serviceaccount.yaml.tpl
@@ -1,7 +1,7 @@
 {{- define "common.kubernetes.serviceaccount" -}}
 {{- $awsAccountId := .global.awsAccountId | required "global.awsAccountId is required." -}}
-{{- $role := .global.serviceAccount.role | default dict }}
-{{- $roleName := .global.serviceAccount.name }}
+{{- $role := .serviceAccount.role | default dict }}
+{{- $roleName := .serviceAccount.name }}
 {{- if $role.name }}
 {{- $roleName = $role.name }}
 {{- end }}

--- a/test/expected_output/cronjobs-serviceaccount.yaml
+++ b/test/expected_output/cronjobs-serviceaccount.yaml
@@ -1,0 +1,83 @@
+---
+# Source: defaults/templates/microservice.yaml.tpl
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-service-account
+  annotations:
+    provi.repository: https://github.com/example/repo
+    test.annotation: hello-test-world
+    eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/test-service-account"
+    eks.amazonaws.com/sts-regional-endpoints: "true"
+  labels:
+    chart: defaults
+    chartVersion: 1.0.0
+    team: cool-team
+---
+# Source: defaults/templates/microservice.yaml.tpl
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: myCoolJob
+  annotations:
+    provi.repository: https://github.com/example/repo
+    test.annotation: hello-test-world
+  labels:
+    app: myCoolJob
+    chart: defaults
+    chartVersion: 1.0.0
+    team: cool-team
+spec:
+  timeZone: Etc/UTC
+  suspend: false
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 5
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          annotations:
+            provi.repository: https://github.com/example/repo
+            test.annotation: hello-test-world
+          labels:
+            selector: defaults-cronjob-myCoolJob
+            app: myCoolJob
+            chart: defaults
+            chartVersion: 1.0.0
+            team: cool-team
+        spec:
+          serviceAccountName: test-service-account
+          automountServiceAccountToken: true
+          restartPolicy: Never
+          terminationGracePeriodSeconds: 30
+          containers:
+            - name: schedule
+              image: docker.io/image:abcd1234
+              imagePullPolicy: Always
+              command:
+                - date
+              securityContext:
+                runAsNonRoot: false
+              envFrom:
+                - secretRef:
+                    name: test-cronjobs
+              resources:
+                limits:
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: type
+                        operator: In
+                        values:
+                          - karpenter

--- a/test/fixtures/Chart.lock
+++ b/test/fixtures/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.7.6
-digest: sha256:7efec400d9b9ce7f634d2c39211be6d0880026fbbd2ac71bd3b6a56357963376
-generated: "2024-08-12T11:56:34.730722-05:00"
+  version: 1.7.7
+digest: sha256:a121c799f2a5fcc74ac3453e7a286bdcc66663a2bd3b321b83b74edc3505adcc
+generated: "2024-08-13T12:12:43.791482-05:00"

--- a/test/fixtures/Chart.yaml
+++ b/test/fixtures/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.7.6"
+    version: "1.7.7"

--- a/test/fixtures/cronjobs/values-global-serviceaccount.yaml
+++ b/test/fixtures/cronjobs/values-global-serviceaccount.yaml
@@ -12,6 +12,8 @@ cronJobs:
   scheduler:
     schedule: "0 * * * *"
     pod:
+      serviceAccount:
+          name: test-service-account
       containers:
         schedule:
           envFrom:

--- a/test/fixtures/cronjobs/values-serviceaccount.yaml
+++ b/test/fixtures/cronjobs/values-serviceaccount.yaml
@@ -6,12 +6,14 @@ global:
     test.annotation: hello-test-world
   labels:
     team: cool-team
+  serviceAccount:
+    name: test-service-account
 
 cronJobs:
-  scheduler:
-    serviceAccount:
-      name: test-service-account
+  myCoolJob:
     schedule: "0 * * * *"
+    serviceAccount:
+      enabled: true
     pod:
       containers:
         schedule:

--- a/test/test_cronjobs.bats
+++ b/test/test_cronjobs.bats
@@ -39,9 +39,8 @@ teardown() {
 
 # bats test_tags=tag:cronjobs-serviceaccount
 @test "cronjobs: includes service account if specified" {
-  skip "this should work, but it doesn't -- in the future, look into lines 11-15 in _cronjob.yaml.tpl"
   helm template -f test/fixtures/cronjobs/values-serviceaccount.yaml test/fixtures/cronjobs/ > "$TEST_TEMP_DIR/serviceaccount_output.yaml"
-  assert diff -ub test/expected_output/values-serviceaccount.yaml "$TEST_TEMP_DIR/serviceaccount_output.yaml"
+  assert diff -ub test/expected_output/cronjobs-serviceaccount.yaml "$TEST_TEMP_DIR/serviceaccount_output.yaml"
 }
 
 # bats test_tags=tag:cronjobs-suspend


### PR DESCRIPTION
I thought that the serviceAccount logic was broken. It wasn't; it's just that it requires an `enabled: true` parameter that I wasn't aware of.

However, there was a logic error in that the serviceaccount template expected to get its data from the global context, but the template is always called with a specific serviceAccount context, and the global assumption could be the source of bugs.

I'm still not sure I like the design of requiring an `enabled` flag, but this is a simpler fix.

Now that I understand how this works, I've enabled a skipped test that wasn't working because it was not referencing the correct file to compare but also because I didn't know about the `enabled` flag. I've also added testing to the Github Actions CI job.