### PR TITLE
Fix autoscaling.behavior and replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2024-10-29
+
+### Fixed
+
+- Remove static replicas from deployment when autoscaling enabled
+- Fixed autoscaling.behavior error
+
 ## [1.7.7] - 2024-08-13
 
 ### Fixed

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.7.8
+version: 1.8.0
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_deployment.yaml.tpl
+++ b/charts/common/templates/_deployment.yaml.tpl
@@ -32,7 +32,9 @@ metadata:
   labels:
     {{- include "common.helper.labels" (dict "global" $global.labels "override" $deploymentDetails.labels) | nindent 4}}
 spec:
+  {{- if not $deploymentDetails.autoscaling }}
   replicas: {{ required (printf "You must set a replicas count for deployment [%s]" $deploymentName ) $deploymentDetails.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       selector: {{ $selector }}

--- a/charts/common/templates/_pod_autoscaler.yaml.tpl
+++ b/charts/common/templates/_pod_autoscaler.yaml.tpl
@@ -19,7 +19,6 @@ spec:
           type: Utilization
           averageUtilization: {{ default 80 .autoscaling.targetUtilization }}
   {{- if .autoscaling.behavior }}
-  behavior:
-  {{ toYaml .autoscaling.behavior | indent 2 }}
+  behavior: {{ toYaml .autoscaling.behavior | nindent 4 }}
   {{- end }}
 {{ end }}

--- a/test/expected_output/autoscaler.yaml
+++ b/test/expected_output/autoscaler.yaml
@@ -14,7 +14,6 @@ metadata:
     chartVersion: 1.0.0
     team: cool-team
 spec:
-  replicas: 3
   selector:
     matchLabels:
       selector: defaults-deployment-web

--- a/test/expected_output/deployments-selector.yaml
+++ b/test/expected_output/deployments-selector.yaml
@@ -48,7 +48,6 @@ metadata:
     chartVersion: 1.0.0
     team: cool-team
 spec:
-  replicas: 3
   selector:
     matchLabels:
       selector: test-foo-selector

--- a/test/expected_output/deployments.yaml
+++ b/test/expected_output/deployments.yaml
@@ -50,7 +50,6 @@ metadata:
     team: cool-team
     testOverrideLabel: hello-override-world
 spec:
-  replicas: 3
   selector:
     matchLabels:
       selector: defaults-deployment-web

--- a/test/expected_output/microservice.yaml
+++ b/test/expected_output/microservice.yaml
@@ -96,7 +96,6 @@ metadata:
     chartVersion: 1.0.0
     team: cool-team
 spec:
-  replicas: 3
   selector:
     matchLabels:
       selector: defaults-deployment-web

--- a/test/expected_output/podspec-basic.yaml
+++ b/test/expected_output/podspec-basic.yaml
@@ -50,7 +50,6 @@ metadata:
     team: cool-team
     testOverrideLabel: hello-override-world
 spec:
-  replicas: 3
   selector:
     matchLabels:
       selector: defaults-deployment-web

--- a/test/fixtures/Chart.lock
+++ b/test/fixtures/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.7.8
-digest: sha256:678a34a766082c16b54e2812afc57404078802330875ed4a75940949ce0b07ca
-generated: "2024-09-30T15:21:59.8489-04:00"
+  version: 1.8.0
+digest: sha256:26e401dc88175ee1ed77e6a070b006b68f3559cf6e9bc02f0801211eb4529915
+generated: "2024-10-29T09:40:19.267101-04:00"

--- a/test/fixtures/Chart.yaml
+++ b/test/fixtures/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.7.8"
+    version: "1.8.0"


### PR DESCRIPTION
Remove static `replicas` from the deployment when autoscaling is enabled. This is causing OutOfSync errors in ArgoCD ([docs](https://argo-cd.readthedocs.io/en/stable/user-guide/best_practices/#leaving-room-for-imperativeness)) for [happy-hour.](https://argocd.prod.provi.beer/applications/happy-hour?node=apps%2FDeployment%2Fhappy-hour%2Fweb%2F0&tab=summary). 

![image](https://github.com/user-attachments/assets/621f54e9-f140-4b91-9641-46aecaf55f0f)

Also fix the syntax issue preventing autoscaling.behavior from rendering. 

https://teamprovi.atlassian.net/browse/DEVOPS-2637