### PR TITLE
DEVOPS-2657 Imperva support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2024-11-04
+
+### added
+
+- Added an `imperva` boolean which will take care of prepending an `origin-` to the hostnames and adding an annotation to add the original hostname to the listener rule conditions so that Imperva requests to that hostname will work.
+
 ## [1.8.0] - 2024-10-29
 
 ### Fixed

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.8.0
+version: 1.8.1
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_ingress.yaml.tpl
+++ b/charts/common/templates/_ingress.yaml.tpl
@@ -36,28 +36,42 @@
 {{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/ssl-redirect" "443" }}
 {{- end }}
 
-{{/* Generate a single hostname based on app/root domains or fall back to hostnames list */}}
+{{/* Generate hostnames with or without 'origin-' prefix based on imperva setting */}}
 {{- $appDomain := default $v.appDomain $global.appDomain }}
 {{- $rootDomain := default $v.rootDomain $global.rootDomain }}
-{{- $hostname := printf "%s.%s" $appDomain $rootDomain }}
-{{- $hostnames := default (list $hostname) $v.hostnames }}
+{{- $defaultHostname := printf "%s.%s" $appDomain $rootDomain }}
+{{- $hostnames := default (list $defaultHostname) $v.hostnames }}
+
+{{/* Apply 'origin-' prefix to each hostname in the list if imperva is true */}}
+{{- if $v.imperva }}
+  {{- $hostnames = (list) }}
+  {{- range $h := $v.hostnames }}
+    {{- $prefixedHostname := printf "origin-%s" $h }}
+    {{- $hostnames = append $hostnames $prefixedHostname }}
+  {{- end }}
+{{- end }}
+
 {{- $rules := $hostnames }}
 {{- if $v.hostnamesNoExternalDNS }}
 {{- $rules = (concat $hostnames $v.hostnamesNoExternalDNS) }}
 {{- end }}
 
+{{/* Set external-dns and Imperva-specific annotations */}}
 {{- $_ := set $finalAnnotations "external-dns.alpha.kubernetes.io/hostname" (join "," $hostnames) }}
+{{- if $v.imperva }}
+  {{- $_ := set $albAnnotations (printf "alb.ingress.kubernetes.io/conditions.%s" $v.service.name) (printf "[{\"Field\":\"host-header\",\"HostHeaderConfig\":{\"Values\":[\"%s\"]}}]" (join "\",\"" $v.hostnames)) }}
+{{- end }}
+
 {{- $finalAnnotations = (mergeOverwrite $finalAnnotations $global.annotations $commonAnnotations $ingressesAnnotations $annotations) }}
 {{- if eq $v.ingressClass "alb" -}}
-
-{{- $finalAnnotations = (mergeOverwrite $finalAnnotations $albAnnotations) }}
+  {{- $finalAnnotations = (mergeOverwrite $finalAnnotations $albAnnotations) }}
 {{- end -}}
 {{- $_ := required (printf $serviceErrorMessage $k) $v.service }}
 
 {{/* Require specific app/root domain if hostnames list is not set */}}
 {{- if not $v.hostnames }}
-{{- $_ := required (printf "You must specify appDomain in the ingress or global section") $appDomain }}
-{{- $_ := required (printf "You must specify rootDomain in the ingress or global section") $rootDomain }}
+  {{- $_ := required (printf "You must specify appDomain in the ingress or global section") $appDomain }}
+  {{- $_ := required (printf "You must specify rootDomain in the ingress or global section") $rootDomain }}
 {{- end }}
 
 ---
@@ -96,3 +110,4 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+

--- a/charts/common/templates/_ingress.yaml.tpl
+++ b/charts/common/templates/_ingress.yaml.tpl
@@ -3,6 +3,7 @@
 {{- $serviceErrorMessage := "You must specify a service with name and port for ingress [%v]" }}
 {{- $schemeErrorMessage := "You must specify a scheme (internal, internet-facing) for ingress [%v]" }}
 {{- $certArnErrorMessage := "You must specify a certificateArn for ingress [%v]" }}
+{{- $impervaSchemeErrorMessage := "If you are putting your service behind Imperva, you must set scheme to internet-facing" }}
 {{- $commonAnnotations := dict }}
 {{- $_ := set $commonAnnotations "nginx.ingress.kubernetes.io/proxy-body-size" "0" }}
 
@@ -25,6 +26,11 @@
 {{- $nameTag := printf "Name=%s-alb" $k }}
 {{- $_ := required (printf $certArnErrorMessage $k) $v.certificateArn}}
 {{- $_ := required (printf $schemeErrorMessage $k) $v.scheme}}
+{{- if $v.imperva }}
+{{- if ne $v.scheme "internet-facing" }}
+  {{- fail $impervaSchemeErrorMessage }}
+{{- end }}
+{{- end }}
 {{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/backend-protocol" "HTTP" }}
 {{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/certificate-arn" $v.certificateArn }}
 {{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/scheme" $v.scheme }}
@@ -110,4 +116,3 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
-

--- a/test/fixtures/Chart.lock
+++ b/test/fixtures/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.0
-digest: sha256:26e401dc88175ee1ed77e6a070b006b68f3559cf6e9bc02f0801211eb4529915
-generated: "2024-10-29T09:40:19.267101-04:00"
+  version: 1.8.1
+digest: sha256:abba04a35d47c865f79e82e6c459578b480eac24064f496fe6627838cade0b58
+generated: "2024-11-04T09:09:34.293331-06:00"

--- a/test/fixtures/Chart.yaml
+++ b/test/fixtures/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.0"
+    version: "1.8.1"

--- a/test/fixtures/ingresses/badvalues-alb-imperva-internal-scheme.yaml
+++ b/test/fixtures/ingresses/badvalues-alb-imperva-internal-scheme.yaml
@@ -12,10 +12,9 @@ ingresses:
     imperva: true
     service:
       port: 8080
-      name: web
-    scheme: internet-facing
+      name: cool_foo_service
+    scheme: internal
     ingressClass: "alb"
     hostnames:
       - test-ingresses.example.com
-      - test2-ingresses.example.com
     certificateArn: "arn:aws:acm:us-east-2:123456789:certificate/abcd1234-1a2b-3c4d-5e6f-987654abcd123"

--- a/test/fixtures/ingresses/values-alb-imperva-multiple-hostnames.yaml
+++ b/test/fixtures/ingresses/values-alb-imperva-multiple-hostnames.yaml
@@ -1,0 +1,21 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+    provi.slack: my-cool-team
+  labels:
+    team: cool-team
+
+ingresses:
+  dummy:
+    imperva: true
+    service:
+      port: 8080
+      name: web
+    scheme: internal
+    ingressClass: "alb"
+    hostnames:
+      - test-ingresses.example.com
+      - test2-ingresses.example.com
+    certificateArn: "arn:aws:acm:us-east-2:123456789:certificate/abcd1234-1a2b-3c4d-5e6f-987654abcd123"

--- a/test/fixtures/ingresses/values-alb-imperva.yaml
+++ b/test/fixtures/ingresses/values-alb-imperva.yaml
@@ -1,0 +1,20 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+    provi.slack: my-cool-team
+  labels:
+    team: cool-team
+
+ingresses:
+  dummy:
+    imperva: true
+    service:
+      port: 8080
+      name: cool_foo_service
+    scheme: internal
+    ingressClass: "alb"
+    hostnames:
+      - test-ingresses.example.com
+    certificateArn: "arn:aws:acm:us-east-2:123456789:certificate/abcd1234-1a2b-3c4d-5e6f-987654abcd123"

--- a/test/fixtures/ingresses/values-alb-imperva.yaml
+++ b/test/fixtures/ingresses/values-alb-imperva.yaml
@@ -13,7 +13,7 @@ ingresses:
     service:
       port: 8080
       name: cool_foo_service
-    scheme: internal
+    scheme: internet-facing
     ingressClass: "alb"
     hostnames:
       - test-ingresses.example.com

--- a/test/test_ingresses.bats
+++ b/test/test_ingresses.bats
@@ -120,3 +120,17 @@ teardown() {
   run helm template -f test/fixtures/ingresses/values-no-ingressclass.yaml test/fixtures/ingresses/
   assert_output --partial "ingressClassName: alb"
 }
+
+# bats test_tags=tag:alb-imperva
+@test "alb-imperva: sets imperva-related annotations and scheme" {
+  run helm template -f test/fixtures/ingresses/values-alb-imperva.yaml test/fixtures/ingresses/
+  assert_output --partial "alb.ingress.kubernetes.io/conditions.cool_foo_service: '[{\"Field\":\"host-header\",\"HostHeaderConfig\":{\"Values\":[\"test-ingresses.example.com\"]}}]'"
+  assert_output --partial "external-dns.alpha.kubernetes.io/hostname: origin-test-ingresses.example.com"
+  assert_output --partial "host: \"origin-test-ingresses.example.com\""
+}
+
+# bats test_tags=tag:alb-imperva-multiple-hostnames
+@test "alb-imperva: sets imperva-related annotations and scheme with multiple hostnames" {
+  run helm template -f test/fixtures/ingresses/values-alb-imperva-multiple-hostnames.yaml test/fixtures/ingresses/
+  assert_output --partial "alb.ingress.kubernetes.io/conditions.web: '[{\"Field\":\"host-header\",\"HostHeaderConfig\":{\"Values\":[\"test-ingresses.example.com\",\"test2-ingresses.example.com\"]}}]'"
+}

--- a/test/test_ingresses.bats
+++ b/test/test_ingresses.bats
@@ -130,7 +130,14 @@ teardown() {
 }
 
 # bats test_tags=tag:alb-imperva-multiple-hostnames
-@test "alb-imperva: sets imperva-related annotations and scheme with multiple hostnames" {
+@test "alb-imperva-multiple-hostnames: sets imperva-related annotations and scheme with multiple hostnames" {
   run helm template -f test/fixtures/ingresses/values-alb-imperva-multiple-hostnames.yaml test/fixtures/ingresses/
   assert_output --partial "alb.ingress.kubernetes.io/conditions.web: '[{\"Field\":\"host-header\",\"HostHeaderConfig\":{\"Values\":[\"test-ingresses.example.com\",\"test2-ingresses.example.com\"]}}]'"
+}
+
+# bats test_tags=tag:alb-imperva-internal-sceme
+@test "alb-imperva-internal-scheme: fails if the scheme is internal" {
+  run helm template -f test/fixtures/ingresses/badvalues-alb-imperva-internal-scheme.yaml test/fixtures/ingresses/
+  assert_failure
+  assert_output --partial "you must set scheme to internet-facing"
 }


### PR DESCRIPTION
Setting `imperva: true` on an Ingress will now change the behvior of the resources created by the template. It will prepend `origin-` to any hostnames (either defined or derived) and also add the `alb.ingress.kubernetes.io/conditions` annotation with the original hostname.

That annotation is defined here:
https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.7/guide/ingress/annotations/#traffic-routing

It sets a listener rule that sets the original hostname as a host header for which it allows requests. Our `origin-` hostname will work with external-dns and the AWS load balancer controller to route requests to the EKS workload, and Imperva will route traffic from the web to the original hostname via the `origin-` hostname. But it will send the request with the host header containing the original hostname.

This hides all that detail behind a simple boolean.