### PR TITLE
DEVOPS-2608 allow unquoted awsAccountId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.2] - 2024-12-17
+
+### Fixed
+
+- If the global variable `awsAccountId` is not quoted, it will ensure it is an int and not an float64 (which will fail to deploy).
+
 ## [1.8.1] - 2024-11-04
 
-### added
+### Added
 
 - Added an `imperva` boolean which will take care of prepending an `origin-` to the hostnames and adding an annotation to add the original hostname to the listener rule conditions so that Imperva requests to that hostname will work.
 

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.8.1
+version: 1.8.2
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_serviceaccount.yaml.tpl
+++ b/charts/common/templates/_serviceaccount.yaml.tpl
@@ -1,5 +1,5 @@
 {{- define "common.kubernetes.serviceaccount" -}}
-{{- $awsAccountId := .global.awsAccountId | required "global.awsAccountId is required." -}}
+{{- $awsAccountId := ( .global.awsAccountId | int ) | required "global.awsAccountId is required." -}}
 {{- $role := .serviceAccount.role | default dict }}
 {{- $roleName := .serviceAccount.name }}
 {{- if $role.name }}

--- a/test/fixtures/Chart.lock
+++ b/test/fixtures/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.1
-digest: sha256:abba04a35d47c865f79e82e6c459578b480eac24064f496fe6627838cade0b58
-generated: "2024-11-04T09:09:34.293331-06:00"
+  version: 1.8.2
+digest: sha256:b1117d1e58734d0e5f8c9d64fbe3fbf457501472418bf52e3d57f7c1086d6a3d
+generated: "2024-12-17T15:21:01.985475-06:00"

--- a/test/fixtures/Chart.yaml
+++ b/test/fixtures/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.1"
+    version: "1.8.2"

--- a/test/fixtures/deployments/badvalues-unquoted-accountid.yaml
+++ b/test/fixtures/deployments/badvalues-unquoted-accountid.yaml
@@ -1,0 +1,61 @@
+global:
+  awsAccountId: 123456789
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+  labels:
+    team: cool-team
+  appDomain: test-app-domain
+  serviceAccount:
+    name: test-deployments
+  env:
+    RAILS_ENV: staging
+
+deployments:
+  web:
+    # default is RollingUpdate
+    strategy: Recreate
+    annotations:
+      test.override.annotation: hello-override-world
+    labels:
+      testOverrideLabel: hello-override-world
+    service:
+      ports:
+        http:
+          port: 8080
+          targetPort: 8080
+          protocol: TCP
+    serviceAccount:
+      enabled: true
+    replicas: 3
+    autoscaling:
+      minReplicas: 3
+      maxReplicas: 6
+    pod:
+      affinity:
+        type: karpenter
+      topologySpreadConstraints:
+        enabled: true
+        matchLabels:
+          app.kubernetes.io/name: test-deployments
+      containers:
+        app:
+          envFrom:
+            - secretRef:
+                name: test-deployments
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m
+              ephemeral-storage: 200Mi
+            limits:
+              memory: 256Mi
+              ephemeral-storage: 200Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+          readinessProbe:
+            disabled: true
+      tolerations:
+        - spot

--- a/test/test_deployments.bats
+++ b/test/test_deployments.bats
@@ -47,3 +47,9 @@ teardown() {
   run helm template -f test/fixtures/deployments/values-serviceaccount-role.yaml test/fixtures/deployments/
   assert_output --partial 'eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/my-cool-role'
 }
+
+# bats test_tags=tag:deployments-unquoted-accountid
+@test "deployments: forces type to string when awsAccountId is unquoted" {
+  helm template -f test/fixtures/deployments/badvalues-unquoted-accountid.yaml test/fixtures/deployments/ > "$TEST_TEMP_DIR/default_output.yaml"
+  assert diff -ub test/expected_output/deployments.yaml "$TEST_TEMP_DIR/default_output.yaml"
+}


### PR DESCRIPTION
When the global variable `awsAccountId` is not quoted, it gets interpreted as a float64 and `123456789` becomes `1.23456789e+08`.

This change ensures that, if the variable isn't quoted, it won't be misinterpreted.