### PR TITLE
DEVOPS-2820 ClusterExternalSecret template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.3] - 2024-12-18
+
+### Added
+
+- Added the `ClusterExternalSecret` template. If you include a `secrets` key in your values file, the template will be rendered.
+
 ## [1.8.2] - 2024-12-17
 
 ### Fixed

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.8.2
+version: 1.8.3
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_clusterexternalsecret.yaml.tpl
+++ b/charts/common/templates/_clusterexternalsecret.yaml.tpl
@@ -1,0 +1,39 @@
+{{- define "common.kubernetes.clusterexternalsecret" -}}
+{{- with .secrets }}
+{{- range $secretName, $secretDetails := . }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterExternalSecret
+metadata:
+  name: {{ .k8sSecretName }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-2"
+    argocd.argoproj.io/hook: PreSync
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ .namespace }}
+  refreshTime: {{ .refreshTime }}
+
+  externalSecretSpec:
+    refreshInterval: {{ .refreshInterval }}
+    secretStoreRef:
+      name: {{ .secretStoreRef.name }}
+      kind: ClusterSecretStore
+    target:
+      name: {{ .k8sSecretName }}
+      creationPolicy: Owner
+    data:
+    {{- range $secretKey := .secretKeys }}
+    - secretKey: {{ $secretKey }}
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: {{ $secretDetails.awsSecretName }}
+        property: {{ $secretKey }}
+    {{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/common/templates/_ingress.yaml.tpl
+++ b/charts/common/templates/_ingress.yaml.tpl
@@ -42,13 +42,13 @@
 {{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/ssl-redirect" "443" }}
 {{- end }}
 
-{{/* Generate hostnames with or without 'origin-' prefix based on imperva setting */}}
+{{- /* Generate hostnames with or without 'origin-' prefix based on imperva setting */}}
 {{- $appDomain := default $v.appDomain $global.appDomain }}
 {{- $rootDomain := default $v.rootDomain $global.rootDomain }}
 {{- $defaultHostname := printf "%s.%s" $appDomain $rootDomain }}
 {{- $hostnames := default (list $defaultHostname) $v.hostnames }}
 
-{{/* Apply 'origin-' prefix to each hostname in the list if imperva is true */}}
+{{- /* Apply 'origin-' prefix to each hostname in the list if imperva is true */}}
 {{- if $v.imperva }}
   {{- $hostnames = (list) }}
   {{- range $h := $v.hostnames }}
@@ -62,7 +62,7 @@
 {{- $rules = (concat $hostnames $v.hostnamesNoExternalDNS) }}
 {{- end }}
 
-{{/* Set external-dns and Imperva-specific annotations */}}
+{{- /* Set external-dns and Imperva-specific annotations */}}
 {{- $_ := set $finalAnnotations "external-dns.alpha.kubernetes.io/hostname" (join "," $hostnames) }}
 {{- if $v.imperva }}
   {{- $_ := set $albAnnotations (printf "alb.ingress.kubernetes.io/conditions.%s" $v.service.name) (printf "[{\"Field\":\"host-header\",\"HostHeaderConfig\":{\"Values\":[\"%s\"]}}]" (join "\",\"" $v.hostnames)) }}
@@ -74,7 +74,7 @@
 {{- end -}}
 {{- $_ := required (printf $serviceErrorMessage $k) $v.service }}
 
-{{/* Require specific app/root domain if hostnames list is not set */}}
+{{- /* Require specific app/root domain if hostnames list is not set */}}
 {{- if not $v.hostnames }}
   {{- $_ := required (printf "You must specify appDomain in the ingress or global section") $appDomain }}
   {{- $_ := required (printf "You must specify rootDomain in the ingress or global section") $rootDomain }}

--- a/charts/common/templates/_microservice.yaml.tpl
+++ b/charts/common/templates/_microservice.yaml.tpl
@@ -1,5 +1,4 @@
 {{- define "common.kubernetes.microservice" -}}
-
 {{- $globalError := "\n\nYou must define the global annotation\n" }}
 {{- $global := deepCopy (required $globalError .Values.global) }}
 {{- $labels := required "You must define global labels" $global.labels}}
@@ -11,33 +10,37 @@
 {{- $_ := set $global.labels "chart" .Chart.Name }}
 {{- $_ := set $global.labels "chartVersion" .Chart.Version }}
 
-{{/* When we want to use a single service account for all workloads */}}
+{{- /* When we want to use a single service account for all workloads */}}
 {{- with $global.serviceAccount }}
 {{ include "common.kubernetes.serviceaccount" (dict "global" $global "serviceAccount" .) }}
-{{- end }}
+{{- end -}}
 
 {{- with .Values.deployments }}
 {{- include "common.kubernetes.deployment" (dict "root" $ "global" $global "deployments" . "Chart" $chart) }}
-{{- end }}
+{{- end -}}
 
 {{- with .Values.statefulSets }}
 {{- include "common.kubernetes.statefulSet" (dict "root" $ "global" $global "statefulSets" . "Chart" $chart) }}
-{{- end }}
+{{- end -}}
 
 {{- with .Values.configMaps }}
 {{- include "common.kubernetes.configMap" (dict "root" $ "global" $global "Files" $files "configMaps" .) }}
-{{- end }}
+{{- end -}}
 
 {{- with .Values.jobs }}
 {{- include "common.kubernetes.job" (dict "root" $ "global" $global "jobs" . "Chart" $chart) -}}
-{{- end }}
+{{- end -}}
 
 {{- with .Values.cronJobs }}
 {{- include "common.kubernetes.cronJob" (dict "root" $ "global" $global "cronJobs" . "Chart" $chart) -}}
-{{- end }}
+{{- end -}}
 
 {{- with .Values.ingresses }}
 {{- include "common.kubernetes.ingress" (dict "root" $ "global" $global "ingresses" .) -}}
-{{- end }}
+{{- end -}}
+
+{{- with .Values.secrets }}
+{{- include "common.kubernetes.clusterexternalsecret" (dict "root" $ "global" $global "secrets" .) -}}
+{{- end -}}
 
 {{- end }}

--- a/charts/common/templates/_topologyspreadconstraints.yaml.tpl
+++ b/charts/common/templates/_topologyspreadconstraints.yaml.tpl
@@ -1,4 +1,4 @@
-{{/* This provides topologySpreadConstraints to the pod spec. See: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ */}}
+{{- /* This provides topologySpreadConstraints to the pod spec. See: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ */}}
 {{- define "common.kubernetes.topologyspreadconstraints" -}}
 topologySpreadConstraints:
 - maxSkew: 1

--- a/test/expected_output/clusterexternalsecret-basic.yaml
+++ b/test/expected_output/clusterexternalsecret-basic.yaml
@@ -1,0 +1,83 @@
+
+---
+# Source: defaults/templates/microservice.yaml.tpl
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterExternalSecret
+metadata:
+  name: mycooldb
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-2"
+    argocd.argoproj.io/hook: PreSync
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: mycoolservice
+  refreshTime: 1m
+
+  externalSecretSpec:
+    refreshInterval: 1h
+    secretStoreRef:
+      name: aws-store
+      kind: ClusterSecretStore
+    target:
+      name: mycooldb
+      creationPolicy: Owner
+    data:
+    - secretKey: username
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: rds!cluster-1a123b45-6c78-901d-e234-f5678901a23b
+        property: username
+    - secretKey: password
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: rds!cluster-1a123b45-6c78-901d-e234-f5678901a23b
+        property: password
+---
+# Source: defaults/templates/microservice.yaml.tpl
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterExternalSecret
+metadata:
+  name: mycoolservice
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-2"
+    argocd.argoproj.io/hook: PreSync
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: mycoolservice
+  refreshTime: 1m
+
+  externalSecretSpec:
+    refreshInterval: 1h
+    secretStoreRef:
+      name: aws-store
+      kind: ClusterSecretStore
+    target:
+      name: mycoolservice
+      creationPolicy: Owner
+    data:
+    - secretKey: MY_COOL_SECRET_1
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: mycoolservice
+        property: MY_COOL_SECRET_1
+    - secretKey: MY_COOL_SECRET_2
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: mycoolservice
+        property: MY_COOL_SECRET_2
+    - secretKey: MY_COOL_SECRET_3
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: mycoolservice
+        property: MY_COOL_SECRET_3

--- a/test/fixtures/Chart.lock
+++ b/test/fixtures/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.2
-digest: sha256:b1117d1e58734d0e5f8c9d64fbe3fbf457501472418bf52e3d57f7c1086d6a3d
-generated: "2024-12-17T15:21:01.985475-06:00"
+  version: 1.8.3
+digest: sha256:c8b09ac13ff4d41bbfd5b940b5a9c274e84c29f6494dc3d3e4ecefbb5791a6ce
+generated: "2024-12-18T12:31:01.967511-06:00"

--- a/test/fixtures/Chart.yaml
+++ b/test/fixtures/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.2"
+    version: "1.8.3"

--- a/test/fixtures/clusterexternalsecret/Chart.lock
+++ b/test/fixtures/clusterexternalsecret/Chart.lock
@@ -1,0 +1,1 @@
+../Chart.lock

--- a/test/fixtures/clusterexternalsecret/Chart.yaml
+++ b/test/fixtures/clusterexternalsecret/Chart.yaml
@@ -1,0 +1,1 @@
+../Chart.yaml

--- a/test/fixtures/clusterexternalsecret/templates/microservice.yaml.tpl
+++ b/test/fixtures/clusterexternalsecret/templates/microservice.yaml.tpl
@@ -1,0 +1,1 @@
+{{- include "common.kubernetes.microservice" . }}

--- a/test/fixtures/clusterexternalsecret/values-basic.yaml
+++ b/test/fixtures/clusterexternalsecret/values-basic.yaml
@@ -1,0 +1,32 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+  labels:
+    team: cool-team
+
+secrets:
+  mycoolservice:
+    k8sSecretName: mycoolservice
+    awsSecretName: mycoolservice
+    namespace: mycoolservice
+    refreshTime: "1m"
+    refreshInterval: "1h"
+    secretStoreRef:
+      name: "aws-store"
+    secretKeys:
+      - MY_COOL_SECRET_1
+      - MY_COOL_SECRET_2
+      - MY_COOL_SECRET_3
+  mycooldb:
+    k8sSecretName: mycooldb
+    awsSecretName: 'rds!cluster-1a123b45-6c78-901d-e234-f5678901a23b'
+    namespace: mycoolservice
+    refreshTime: "1m"
+    refreshInterval: "1h"
+    secretStoreRef:
+      name: "aws-store"
+    secretKeys:
+      - username
+      - password

--- a/test/fixtures/deployments/values-with-secrets.yaml
+++ b/test/fixtures/deployments/values-with-secrets.yaml
@@ -1,0 +1,86 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+  labels:
+    team: cool-team
+  appDomain: test-app-domain
+  serviceAccount:
+    name: test-deployments
+  env:
+    RAILS_ENV: staging
+
+deployments:
+  web:
+    # default is RollingUpdate
+    strategy: Recreate
+    annotations:
+      test.override.annotation: hello-override-world
+    labels:
+      testOverrideLabel: hello-override-world
+    service:
+      ports:
+        http:
+          port: 8080
+          targetPort: 8080
+          protocol: TCP
+    serviceAccount:
+      enabled: true
+    replicas: 3
+    autoscaling:
+      minReplicas: 3
+      maxReplicas: 6
+    pod:
+      affinity:
+        type: karpenter
+      topologySpreadConstraints:
+        enabled: true
+        matchLabels:
+          app.kubernetes.io/name: test-deployments
+      containers:
+        app:
+          envFrom:
+            - secretRef:
+                name: test-deployments
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m
+              ephemeral-storage: 200Mi
+            limits:
+              memory: 256Mi
+              ephemeral-storage: 200Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+          readinessProbe:
+            disabled: true
+      tolerations:
+        - spot
+
+secrets:
+  mycoolservice:
+    k8sSecretName: mycoolservice
+    awsSecretName: mycoolservice
+    namespace: mycoolservice
+    refreshTime: "1m"
+    refreshInterval: "1h"
+    secretStoreRef:
+      name: "aws-store"
+    secretKeys:
+      - MY_COOL_SECRET_1
+      - MY_COOL_SECRET_2
+      - MY_COOL_SECRET_3
+  mycooldb:
+    k8sSecretName: mycooldb
+    awsSecretName: 'rds!cluster-1a123b45-6c78-901d-e234-f5678901a23b'
+    namespace: mycoolservice
+    refreshTime: "1m"
+    refreshInterval: "1h"
+    secretStoreRef:
+      name: "aws-store"
+    secretKeys:
+      - username
+      - password

--- a/test/test_clusterexternalsecret.bats
+++ b/test/test_clusterexternalsecret.bats
@@ -1,0 +1,28 @@
+# bats file_tags=tag:all, tag:clusterexternalsecret
+setup() {
+  load 'test_helper/bats-support/load'
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-file/load'
+
+  AWS_PROFILE=provi-development helm dep update test/fixtures/clusterexternalsecret &> /dev/null
+
+  TEST_TEMP_DIR="$(temp_make)"
+}
+
+teardown() {
+  temp_del "$TEST_TEMP_DIR"
+}
+
+# bats test_tags=tag:basic
+@test "clusterexternalsecret: outputs a template" {
+  run helm template -f test/fixtures/clusterexternalsecret/values-basic.yaml test/fixtures/clusterexternalsecret/
+  assert_output --partial 'kind: ClusterExternalSecret'
+  assert_output --partial 'helm.sh/hook: pre-install,pre-upgrade'
+  assert_output --partial 'argocd.argoproj.io/hook: PreSync'
+}
+
+# bats test_tags=tag:basic
+@test "clusterexternalsecret: matches expected output" {
+  helm template -f test/fixtures/clusterexternalsecret/values-basic.yaml test/fixtures/clusterexternalsecret/ > "$TEST_TEMP_DIR/default_output.yaml"
+  assert diff -ub test/expected_output/clusterexternalsecret-basic.yaml "$TEST_TEMP_DIR/default_output.yaml"
+}

--- a/test/test_deployments.bats
+++ b/test/test_deployments.bats
@@ -53,3 +53,11 @@ teardown() {
   helm template -f test/fixtures/deployments/badvalues-unquoted-accountid.yaml test/fixtures/deployments/ > "$TEST_TEMP_DIR/default_output.yaml"
   assert diff -ub test/expected_output/deployments.yaml "$TEST_TEMP_DIR/default_output.yaml"
 }
+
+# bats test_tags=tag:deployments-with-secrets
+@test "deployments: renders ClusterExternalSecret if secrets are included" {
+  run helm template -f test/fixtures/deployments/values-with-secrets.yaml test/fixtures/deployments/
+  assert_output --partial 'kind: ClusterExternalSecret'
+  assert_output --partial 'key: rds!cluster-1a123b45-6c78-901d-e234-f5678901a23b'
+  assert_output --partial 'secretKey: MY_COOL_SECRET_1'
+}


### PR DESCRIPTION
Adds a `secrets` key which will cause the `ClusterExternalSecret` template to be rendered. This allows us to create secrets in AWS Secretsmanager which get turned into Kubernetes secrets, and can then be mounted as environment variables in workloads.