### PR TITLE
DEVOPS-2592 set healthcheckPort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.5] - 2024-12-19
+
+### Added
+
+- You can include a `healthcheckPort` in the `ingresses` section, which will add the `alb.ingress.kubernetes.io/healthcheck-port` annotation to the Ingress.
+
 ## [1.8.4] - 2024-12-18
 
 ### Added

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.8.4
+version: 1.8.5
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_ingress.yaml.tpl
+++ b/charts/common/templates/_ingress.yaml.tpl
@@ -37,6 +37,9 @@
 {{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/tags" $nameTag }}
 {{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/target-type" "ip" }}
 {{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/healthcheck-path" $healthcheckPath }}
+{{- if $v.healthcheckPort }}
+{{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/healthcheck-port" $v.healthcheckPort }}
+{{- end }}
 {{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/healthcheck-protocol" "HTTP" }}
 {{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/listen-ports" "[{\"HTTP\": 80}, {\"HTTPS\":443}]" }}
 {{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/ssl-redirect" "443" }}

--- a/test/fixtures/ingresses/values-healthcheck-port.yaml
+++ b/test/fixtures/ingresses/values-healthcheck-port.yaml
@@ -1,0 +1,21 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+    provi.slack: my-cool-team
+  labels:
+    team: cool-team
+
+ingresses:
+  dummy:
+    service:
+      port: 8181
+      name: web
+    scheme: internal
+    ingressClass: "alb"
+    hostnames:
+      - test-ingresses.example.com
+    certificateArn: "arn:aws:acm:us-east-2:123456789:certificate/abcd1234-1a2b-3c4d-5e6f-987654abcd123"
+    healthcheckPath: /healthz
+    healthcheckPort: 8181

--- a/test/test_ingresses.bats
+++ b/test/test_ingresses.bats
@@ -141,3 +141,9 @@ teardown() {
   assert_failure
   assert_output --partial "you must set scheme to internet-facing"
 }
+
+# bats test_tags=tag:alb-healthcheck-port
+@test "alb-healthcheck-port: sets healthcheck-port annotation if specified" {
+  run helm template -f test/fixtures/ingresses/values-healthcheck-port.yaml test/fixtures/ingresses/
+  assert_output --partial "alb.ingress.kubernetes.io/healthcheck-port: 8181"
+}


### PR DESCRIPTION
Adding the `healthcheckPort` key to the `ingresses` section creates the `alb.ingress.kubernetes.io/healthcheck-port` annotation on the Ingress.