### PR TITLE
DEVOPS-2833 healthcheck protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.6] - 2024-12-19
+
+### Added
+
+- You can include a `healthcheckProtocol` in the `ingresses` section, which will add the `alb.ingress.kubernetes.io/healthcheck-protocol` annotation to the Ingress.
+
 ## [1.8.5] - 2024-12-19
 
 ### Added

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.8.5
+version: 1.8.6
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_ingress.yaml.tpl
+++ b/charts/common/templates/_ingress.yaml.tpl
@@ -23,6 +23,7 @@
 {{- $albAnnotations := dict }}
 {{ if eq $v.ingressClass "alb" }}
 {{- $healthcheckPath := default "/health" $v.healthcheckPath }}
+{{- $healthcheckProtocol := default "HTTP" $v.healthcheckProtocol }}
 {{- $nameTag := printf "Name=%s-alb" $k }}
 {{- $_ := required (printf $certArnErrorMessage $k) $v.certificateArn}}
 {{- $_ := required (printf $schemeErrorMessage $k) $v.scheme}}
@@ -40,7 +41,7 @@
 {{- if $v.healthcheckPort }}
 {{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/healthcheck-port" $v.healthcheckPort }}
 {{- end }}
-{{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/healthcheck-protocol" "HTTP" }}
+{{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/healthcheck-protocol" ( upper $healthcheckProtocol ) }}
 {{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/listen-ports" "[{\"HTTP\": 80}, {\"HTTPS\":443}]" }}
 {{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/ssl-redirect" "443" }}
 {{- end }}

--- a/test/fixtures/Chart.lock
+++ b/test/fixtures/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.4
-digest: sha256:e54f6728a757388f15054b2c4b02553cc26cc621eafe029231a6478c20a4e7de
-generated: "2024-12-18T16:50:37.387052-06:00"
+  version: 1.8.6
+digest: sha256:7460d26f25c5d5da85af608e9e2d63afd2ab6cd1de5122ed808719b082c10a35
+generated: "2024-12-19T15:43:16.406171-06:00"

--- a/test/fixtures/Chart.yaml
+++ b/test/fixtures/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.4"
+    version: "1.8.6"

--- a/test/fixtures/ingresses/values-healthcheck-protocol.yaml
+++ b/test/fixtures/ingresses/values-healthcheck-protocol.yaml
@@ -1,0 +1,21 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+    provi.slack: my-cool-team
+  labels:
+    team: cool-team
+
+ingresses:
+  dummy:
+    service:
+      port: 8080
+      name: web
+    scheme: internal
+    ingressClass: "alb"
+    hostnames:
+      - test-ingresses.example.com
+    certificateArn: "arn:aws:acm:us-east-2:123456789:certificate/abcd1234-1a2b-3c4d-5e6f-987654abcd123"
+    healthcheckPath: /healthz
+    healthcheckProtocol: https # note this should be capitalized, but it's lowercase for testing purposes

--- a/test/test_ingresses.bats
+++ b/test/test_ingresses.bats
@@ -147,3 +147,9 @@ teardown() {
   run helm template -f test/fixtures/ingresses/values-healthcheck-port.yaml test/fixtures/ingresses/
   assert_output --partial "alb.ingress.kubernetes.io/healthcheck-port: 8181"
 }
+
+# bats test_tags=tag:alb-healthcheck-protocol
+@test "alb-healthcheck-protocol: sets healthcheck-protocl annotation if specified" {
+  run helm template -f test/fixtures/ingresses/values-healthcheck-protocol.yaml test/fixtures/ingresses/
+  assert_output --partial "alb.ingress.kubernetes.io/healthcheck-protocol: HTTPS"
+}


### PR DESCRIPTION
Allows you to set `healthcheckProtocol` in the `ingresses` section, which will add the `alb.ingress.kubernetes.io/healthcheck-protocol` annotation to the Ingress.