### PR TITLE
Add ingress list for hostname aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.7] - 2024-12-23
+
+### Added
+
+- Added the `hostnameAliases` list for services to specify additional HTTP host headers that should be accepted  by the load balancer, e.g. if you have a CNAME alias to a domain in the hostnames list.
+
 ## [1.8.6] - 2024-12-19
 
 ### Added

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.8.6
+version: 1.8.7
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_ingress.yaml.tpl
+++ b/charts/common/templates/_ingress.yaml.tpl
@@ -68,8 +68,12 @@
 
 {{- /* Set external-dns and Imperva-specific annotations */}}
 {{- $_ := set $finalAnnotations "external-dns.alpha.kubernetes.io/hostname" (join "," $hostnames) }}
-{{- if $v.imperva }}
-  {{- $_ := set $albAnnotations (printf "alb.ingress.kubernetes.io/conditions.%s" $v.service.name) (printf "[{\"Field\":\"host-header\",\"HostHeaderConfig\":{\"Values\":[\"%s\"]}}]" (join "\",\"" $v.hostnames)) }}
+
+{{- $albHostnames := default list $v.hostnameAliases }}
+{{- /* Add host-header annotations whenever using imperva or additional hostname aliases */}}
+{{- if or $albHostnames $v.imperva }}
+  {{- $albHostnames = concat $v.hostnames $albHostnames }}
+  {{- $_ := set $albAnnotations (printf "alb.ingress.kubernetes.io/conditions.%s" $v.service.name) (printf "[{\"Field\":\"host-header\",\"HostHeaderConfig\":{\"Values\":[\"%s\"]}}]" (join "\",\"" $albHostnames)) }}
 {{- end }}
 
 {{- $finalAnnotations = (mergeOverwrite $finalAnnotations $global.annotations $commonAnnotations $ingressesAnnotations $annotations) }}

--- a/test/fixtures/Chart.lock
+++ b/test/fixtures/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.6
-digest: sha256:7460d26f25c5d5da85af608e9e2d63afd2ab6cd1de5122ed808719b082c10a35
-generated: "2024-12-19T15:43:16.406171-06:00"
+  version: 1.8.7
+digest: sha256:9cc33c986f74796976839313cba76a8d431de6edc89ec6d22e9d75aa2d5aca27
+generated: "2024-12-23T13:14:23.492561-05:00"

--- a/test/fixtures/Chart.yaml
+++ b/test/fixtures/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.6"
+    version: "1.8.7"

--- a/test/fixtures/ingresses/values-alb-aliases.yaml
+++ b/test/fixtures/ingresses/values-alb-aliases.yaml
@@ -1,0 +1,22 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+    provi.slack: my-cool-team
+  labels:
+    team: cool-team
+
+ingresses:
+  dummy:
+    service:
+      port: 8080
+      name: cool_foo_service
+    scheme: internet-facing
+    ingressClass: "alb"
+    hostnames:
+      - test-ingresses.example.com
+    hostnameAliases:
+      - alias-subdomain1.example.com
+      - alias-subdomain2.example.com
+    certificateArn: "arn:aws:acm:us-east-2:123456789:certificate/abcd1234-1a2b-3c4d-5e6f-987654abcd123"

--- a/test/test_ingresses.bats
+++ b/test/test_ingresses.bats
@@ -153,3 +153,9 @@ teardown() {
   run helm template -f test/fixtures/ingresses/values-healthcheck-protocol.yaml test/fixtures/ingresses/
   assert_output --partial "alb.ingress.kubernetes.io/healthcheck-protocol: HTTPS"
 }
+
+# bats test_tags=tag:alb-aliases
+@test "alb-aliases: sets alb host header annotations with hostnameAliases" {
+  run helm template -f test/fixtures/ingresses/values-alb-aliases.yaml test/fixtures/ingresses/
+  assert_output --partial "alb.ingress.kubernetes.io/conditions.cool_foo_service: '[{\"Field\":\"host-header\",\"HostHeaderConfig\":{\"Values\":[\"test-ingresses.example.com\",\"alias-subdomain1.example.com\",\"alias-subdomain2.example.com\"]}}]'"
+}


### PR DESCRIPTION
Allows specifying a list of aliases like

```yaml
    hostnames:
      - d2.easteighth.com
    hostnameAliases:
      - distiller.easteighth.com
      - qb.easteighth.com
```

And adds these to the necessary host-header config in ALB.

This is needed for alternate host headers to work together with the imperva option in our charts which also sets/overrides this annotation.