### PR TITLE
DEVOPS-1112 Pod Disruption Budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.8] - 2025-01-03
+
+### Added
+
+- Pod Disruption Budgets can be defined by adding a `podDisruptionBudget` to a deployment with `minAvailable` and `maxUnavailable` specified as described [in the Kubernetes documentation](https://kubernetes.io/docs/tasks/run-application/configure-pdb/).
+
 ## [1.8.7] - 2024-12-23
 
 ### Added

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.8.7
+version: 1.8.8
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_deployment.yaml.tpl
+++ b/charts/common/templates/_deployment.yaml.tpl
@@ -22,6 +22,10 @@
 {{ include "common.kubernetes.podautoscaler" (dict "global" $global "selector" $deploymentName "autoscaling" .) }}
 {{- end }}
 
+{{- with $deploymentDetails.podDisruptionBudget }}
+{{- include "common.kubernetes.pod_disruption_budget" (dict "chart" $chart "deploymentName" $deploymentName "selector" $selector "pdb" .) }}
+{{- end }}
+
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/common/templates/_microservice.yaml.tpl
+++ b/charts/common/templates/_microservice.yaml.tpl
@@ -42,5 +42,4 @@
 {{- with .Values.secrets }}
 {{- include "common.kubernetes.clusterexternalsecret" (dict "root" $ "global" $global "secrets" .) -}}
 {{- end -}}
-
 {{- end }}

--- a/charts/common/templates/_pod_disruption_budget.yaml.tpl
+++ b/charts/common/templates/_pod_disruption_budget.yaml.tpl
@@ -1,0 +1,17 @@
+{{- define "common.kubernetes.pod_disruption_budget" -}}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ printf "%s-%s-pdb" .chart.Name .deploymentName }}
+spec:
+{{- if .pdb.minAvailable }}
+  minAvailable: {{ .pdb.minAvailable }}
+{{- end }}
+{{- if .pdb.maxUnavailable }}
+  maxUnavailable: {{ .pdb.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ .selector }}
+{{- end }}

--- a/test/expected_output/affinity.yaml
+++ b/test/expected_output/affinity.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -10,24 +10,24 @@ metadata:
   labels:
     app: web
     app.kubernetes.io/name: dummy
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
   replicas: 3
   selector:
     matchLabels:
-      selector: defaults-deployment-web
+      selector: my-cool-app-deployment-web
   template:
     metadata:
       annotations:
         provi.repository: https://github.com/example/repo
         provi.slack: my-cool-team
       labels:
-        selector: defaults-deployment-web
+        selector: my-cool-app-deployment-web
         app: web
         app.kubernetes.io/name: dummy
-        chart: defaults
+        chart: my-cool-app
         chartVersion: 1.0.0
         team: cool-team
     spec:

--- a/test/expected_output/autoscaler.yaml
+++ b/test/expected_output/autoscaler.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -10,23 +10,23 @@ metadata:
   labels:
     app: web
     app.kubernetes.io/name: dummy
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
   selector:
     matchLabels:
-      selector: defaults-deployment-web
+      selector: my-cool-app-deployment-web
   template:
     metadata:
       annotations:
         provi.repository: https://github.com/example/repo
         provi.slack: my-cool-team
       labels:
-        selector: defaults-deployment-web
+        selector: my-cool-app-deployment-web
         app: web
         app.kubernetes.io/name: dummy
-        chart: defaults
+        chart: my-cool-app
         chartVersion: 1.0.0
         team: cool-team
     spec:
@@ -91,7 +91,7 @@ spec:
                     values:
                       - karpenter
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/test/expected_output/clusterexternalsecret-basic.yaml
+++ b/test/expected_output/clusterexternalsecret-basic.yaml
@@ -1,6 +1,6 @@
 
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterExternalSecret
 metadata:
@@ -38,7 +38,7 @@ spec:
         key: rds!cluster-1a123b45-6c78-901d-e234-f5678901a23b
         property: password
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterExternalSecret
 metadata:

--- a/test/expected_output/configmaps.yaml
+++ b/test/expected_output/configmaps.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,7 +7,7 @@ metadata:
   annotations:
     provi.repository: https://github.com/example/repo
   labels:
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 data:

--- a/test/expected_output/containers-basic.yaml
+++ b/test/expected_output/containers-basic.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,22 +8,22 @@ metadata:
     provi.repository: https://github.com/example/repo
   labels:
     app: web
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
   replicas: 1
   selector:
     matchLabels:
-      selector: defaults-deployment-web
+      selector: my-cool-app-deployment-web
   template:
     metadata:
       annotations:
         provi.repository: https://github.com/example/repo
       labels:
-        selector: defaults-deployment-web
+        selector: my-cool-app-deployment-web
         app: web
-        chart: defaults
+        chart: my-cool-app
         chartVersion: 1.0.0
         team: cool-team
     spec:

--- a/test/expected_output/cronjobs-global-serviceaccount.yaml
+++ b/test/expected_output/cronjobs-global-serviceaccount.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,11 +9,11 @@ metadata:
     eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/test-service-account"
     eks.amazonaws.com/sts-regional-endpoints: "true"
   labels:
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -22,7 +22,7 @@ metadata:
     provi.repository: https://github.com/example/repo
   labels:
     app: scheduler
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
@@ -42,9 +42,9 @@ spec:
           annotations:
             provi.repository: https://github.com/example/repo
           labels:
-            selector: defaults-cronjob-scheduler
+            selector: my-cool-app-cronjob-scheduler
             app: scheduler
-            chart: defaults
+            chart: my-cool-app
             chartVersion: 1.0.0
             team: cool-team
         spec:

--- a/test/expected_output/cronjobs-serviceaccount.yaml
+++ b/test/expected_output/cronjobs-serviceaccount.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,11 +10,11 @@ metadata:
     eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/test-service-account"
     eks.amazonaws.com/sts-regional-endpoints: "true"
   labels:
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -24,7 +24,7 @@ metadata:
     test.annotation: hello-test-world
   labels:
     app: myCoolJob
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
@@ -45,9 +45,9 @@ spec:
             provi.repository: https://github.com/example/repo
             test.annotation: hello-test-world
           labels:
-            selector: defaults-cronjob-myCoolJob
+            selector: my-cool-app-cronjob-myCoolJob
             app: myCoolJob
-            chart: defaults
+            chart: my-cool-app
             chartVersion: 1.0.0
             team: cool-team
         spec:

--- a/test/expected_output/cronjobs.yaml
+++ b/test/expected_output/cronjobs.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -10,7 +10,7 @@ metadata:
     test.override.annotation: hello-override-world
   labels:
     app: scheduler
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
     testOverrideLabel: hello-override-world
@@ -33,9 +33,9 @@ spec:
             test.annotation: hello-test-world
             test.override.annotation: hello-override-world
           labels:
-            selector: defaults-cronjob-scheduler
+            selector: my-cool-app-cronjob-scheduler
             app: scheduler
-            chart: defaults
+            chart: my-cool-app
             chartVersion: 1.0.0
             team: cool-team
             testOverrideLabel: hello-override-world

--- a/test/expected_output/deployments-selector.yaml
+++ b/test/expected_output/deployments-selector.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,11 +9,11 @@ metadata:
     eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/test-deployments"
     eks.amazonaws.com/sts-regional-endpoints: "true"
   labels:
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,7 +22,7 @@ metadata:
     provi.repository: https://github.com/example/repo
   labels:
     app: web
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
@@ -35,7 +35,7 @@ spec:
       protocol: TCP
       targetPort: 8080
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -44,7 +44,7 @@ metadata:
     provi.repository: https://github.com/example/repo
   labels:
     app: web
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
@@ -58,7 +58,7 @@ spec:
       labels:
         selector: test-foo-selector
         app: web
-        chart: defaults
+        chart: my-cool-app
         chartVersion: 1.0.0
         team: cool-team
     spec:
@@ -122,7 +122,7 @@ spec:
                     values:
                       - karpenter
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/test/expected_output/deployments.yaml
+++ b/test/expected_output/deployments.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,11 +9,11 @@ metadata:
     eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/test-deployments"
     eks.amazonaws.com/sts-regional-endpoints: "true"
   labels:
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,12 +22,12 @@ metadata:
     provi.repository: https://github.com/example/repo
   labels:
     app: web
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
   selector:
-    selector: defaults-deployment-web
+    selector: my-cool-app-deployment-web
   type: ClusterIP
   ports:
     - name: http
@@ -35,7 +35,7 @@ spec:
       protocol: TCP
       targetPort: 8080
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -45,14 +45,14 @@ metadata:
     test.override.annotation: hello-override-world
   labels:
     app: web
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
     testOverrideLabel: hello-override-world
 spec:
   selector:
     matchLabels:
-      selector: defaults-deployment-web
+      selector: my-cool-app-deployment-web
   strategy:
     Recreate
   template:
@@ -61,9 +61,9 @@ spec:
         provi.repository: https://github.com/example/repo
         test.override.annotation: hello-override-world
       labels:
-        selector: defaults-deployment-web
+        selector: my-cool-app-deployment-web
         app: web
-        chart: defaults
+        chart: my-cool-app
         chartVersion: 1.0.0
         team: cool-team
         testOverrideLabel: hello-override-world
@@ -128,7 +128,7 @@ spec:
                     values:
                       - karpenter
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/test/expected_output/ingresses-alb.yaml
+++ b/test/expected_output/ingresses-alb.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -20,7 +20,7 @@ metadata:
     provi.slack: my-cool-team
     external-dns.alpha.kubernetes.io/ttl: "10"
   labels:
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:

--- a/test/expected_output/ingresses-basicauth.yaml
+++ b/test/expected_output/ingresses-basicauth.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -13,7 +13,7 @@ metadata:
     provi.repository: https://github.com/example/repo
     external-dns.alpha.kubernetes.io/ttl: "10"
   labels:
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:

--- a/test/expected_output/ingresses-nginx-external.yaml
+++ b/test/expected_output/ingresses-nginx-external.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -13,7 +13,7 @@ metadata:
     provi.repository: https://github.com/example/repo
     external-dns.alpha.kubernetes.io/ttl: "10"
   labels:
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:

--- a/test/expected_output/ingresses-nodns.yaml
+++ b/test/expected_output/ingresses-nodns.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -10,7 +10,7 @@ metadata:
     provi.repository: https://github.com/example/repo
     external-dns.alpha.kubernetes.io/ttl: "10"
   labels:
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:

--- a/test/expected_output/ingresses-oauth.yaml
+++ b/test/expected_output/ingresses-oauth.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -12,7 +12,7 @@ metadata:
     provi.repository: https://github.com/example/repo
     external-dns.alpha.kubernetes.io/ttl: "10"
   labels:
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:

--- a/test/expected_output/jobs.yaml
+++ b/test/expected_output/jobs.yaml
@@ -1,6 +1,6 @@
 
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -12,7 +12,7 @@ metadata:
     provi.repository: https://github.com/example/repo
   labels:
     app: migrations
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
@@ -27,9 +27,9 @@ spec:
         helm.sh/hook-weight: "0"
         provi.repository: https://github.com/example/repo
       labels:
-        selector: defaults-job-migrations
+        selector: my-cool-app-job-migrations
         app: migrations
-        chart: defaults
+        chart: my-cool-app
         chartVersion: 1.0.0
         team: cool-team
     spec:

--- a/test/expected_output/microservice.yaml
+++ b/test/expected_output/microservice.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,11 +11,11 @@ metadata:
     eks.amazonaws.com/sts-regional-endpoints: "true"
   labels:
     app.kubernetes.io/name: dummy
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -25,7 +25,7 @@ metadata:
     provi.slack: my-cool-team
   labels:
     app.kubernetes.io/name: dummy
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 data:
@@ -33,7 +33,7 @@ data:
   number: "1"
   properties: "fruit.type=banana\n"
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: Service
 metadata:
@@ -44,12 +44,12 @@ metadata:
   labels:
     app: web
     app.kubernetes.io/name: dummy
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
   selector:
-    selector: defaults-deployment-web
+    selector: my-cool-app-deployment-web
   type: ClusterIP
   ports:
     - name: http
@@ -57,7 +57,7 @@ spec:
       protocol: TCP
       targetPort: 8080
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: Service
 metadata:
@@ -68,12 +68,12 @@ metadata:
   labels:
     app: worker
     app.kubernetes.io/name: dummy
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
   selector:
-    selector: defaults-statefulset-worker
+    selector: my-cool-app-statefulset-worker
   type: ClusterIP
   ports:
     - name: http
@@ -81,7 +81,7 @@ spec:
       protocol: TCP
       targetPort: 8080
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -92,23 +92,23 @@ metadata:
   labels:
     app: web
     app.kubernetes.io/name: dummy
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
   selector:
     matchLabels:
-      selector: defaults-deployment-web
+      selector: my-cool-app-deployment-web
   template:
     metadata:
       annotations:
         provi.repository: https://github.com/example/repo
         provi.slack: my-cool-team
       labels:
-        selector: defaults-deployment-web
+        selector: my-cool-app-deployment-web
         app: web
         app.kubernetes.io/name: dummy
-        chart: defaults
+        chart: my-cool-app
         chartVersion: 1.0.0
         team: cool-team
     spec:
@@ -178,7 +178,7 @@ spec:
                     values:
                       - karpenter
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -198,7 +198,7 @@ spec:
           type: Utilization
           averageUtilization: 80
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -209,7 +209,7 @@ metadata:
   labels:
     app: worker
     app.kubernetes.io/name: dummy
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
@@ -219,17 +219,17 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      selector: defaults-statefulset-worker
+      selector: my-cool-app-statefulset-worker
   template:
     metadata:
       annotations:
         provi.repository: https://github.com/example/repo
         provi.slack: my-cool-team
       labels:
-        selector: defaults-statefulset-worker
+        selector: my-cool-app-statefulset-worker
         app: worker
         app.kubernetes.io/name: dummy
-        chart: defaults
+        chart: my-cool-app
         chartVersion: 1.0.0
         team: cool-team
     spec:
@@ -295,7 +295,7 @@ spec:
           requests:
             storage: 10Gi
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -306,7 +306,7 @@ metadata:
   labels:
     app: scheduler
     app.kubernetes.io/name: dummy
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
@@ -327,10 +327,10 @@ spec:
             provi.repository: https://github.com/example/repo
             provi.slack: my-cool-team
           labels:
-            selector: defaults-cronjob-scheduler
+            selector: my-cool-app-cronjob-scheduler
             app: scheduler
             app.kubernetes.io/name: dummy
-            chart: defaults
+            chart: my-cool-app
             chartVersion: 1.0.0
             team: cool-team
         spec:
@@ -370,7 +370,7 @@ spec:
                         values:
                           - karpenter
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -385,7 +385,7 @@ metadata:
     external-dns.alpha.kubernetes.io/ttl: "10"
   labels:
     app.kubernetes.io/name: dummy
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
@@ -412,7 +412,7 @@ spec:
                 port:
                   number: 8080
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -426,7 +426,7 @@ metadata:
   labels:
     app: migrations
     app.kubernetes.io/name: dummy
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
@@ -442,10 +442,10 @@ spec:
         provi.repository: https://github.com/example/repo
         provi.slack: my-cool-team
       labels:
-        selector: defaults-job-migrations
+        selector: my-cool-app-job-migrations
         app: migrations
         app.kubernetes.io/name: dummy
-        chart: defaults
+        chart: my-cool-app
         chartVersion: 1.0.0
         team: cool-team
     spec:

--- a/test/expected_output/podspec-basic.yaml
+++ b/test/expected_output/podspec-basic.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,11 +9,11 @@ metadata:
     eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/test-podspec"
     eks.amazonaws.com/sts-regional-endpoints: "true"
   labels:
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,12 +22,12 @@ metadata:
     provi.repository: https://github.com/example/repo
   labels:
     app: web
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
   selector:
-    selector: defaults-deployment-web
+    selector: my-cool-app-deployment-web
   type: ClusterIP
   ports:
     - name: http
@@ -35,7 +35,7 @@ spec:
       protocol: TCP
       targetPort: 8080
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -45,14 +45,14 @@ metadata:
     test.override.annotation: hello-override-world
   labels:
     app: web
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
     testOverrideLabel: hello-override-world
 spec:
   selector:
     matchLabels:
-      selector: defaults-deployment-web
+      selector: my-cool-app-deployment-web
   strategy:
     Recreate
   template:
@@ -61,9 +61,9 @@ spec:
         provi.repository: https://github.com/example/repo
         test.override.annotation: hello-override-world
       labels:
-        selector: defaults-deployment-web
+        selector: my-cool-app-deployment-web
         app: web
-        chart: defaults
+        chart: my-cool-app
         chartVersion: 1.0.0
         team: cool-team
         testOverrideLabel: hello-override-world
@@ -128,7 +128,7 @@ spec:
                     values:
                       - karpenter
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/test/expected_output/podspec_output.yaml
+++ b/test/expected_output/podspec_output.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,11 +9,11 @@ metadata:
     eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/test-podspec"
     eks.amazonaws.com/sts-regional-endpoints: "true"
   labels:
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,12 +22,12 @@ metadata:
     provi.repository: https://github.com/example/repo
   labels:
     app: web
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: devops
 spec:
   selector:
-    selector: defaults-deployment-web
+    selector: my-cool-app-deployment-web
   type: ClusterIP
   ports:
     - name: http
@@ -35,7 +35,7 @@ spec:
       protocol: TCP
       targetPort: 8080
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -45,7 +45,7 @@ metadata:
     test.override.annotation: hello-override-world
   labels:
     app: web
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: devops
     testOverrideLabel: hello-override-world
@@ -53,7 +53,7 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      selector: defaults-deployment-web
+      selector: my-cool-app-deployment-web
   strategy:
     Recreate
   template:
@@ -62,9 +62,9 @@ spec:
         provi.repository: https://github.com/example/repo
         test.override.annotation: hello-override-world
       labels:
-        selector: defaults-deployment-web
+        selector: my-cool-app-deployment-web
         app: web
-        chart: defaults
+        chart: my-cool-app
         chartVersion: 1.0.0
         team: devops
         testOverrideLabel: hello-override-world
@@ -129,7 +129,7 @@ spec:
                     values:
                       - karpenter
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/test/expected_output/statefulsets.yaml
+++ b/test/expected_output/statefulsets.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,11 +9,11 @@ metadata:
     eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/test-statefulsets"
     eks.amazonaws.com/sts-regional-endpoints: "true"
   labels:
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,12 +22,12 @@ metadata:
     provi.repository: https://github.com/example/repo
   labels:
     app: worker
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
   selector:
-    selector: defaults-statefulset-worker
+    selector: my-cool-app-statefulset-worker
   type: ClusterIP
   ports:
     - name: http
@@ -35,7 +35,7 @@ spec:
       protocol: TCP
       targetPort: 8080
 ---
-# Source: defaults/templates/microservice.yaml.tpl
+# Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -44,7 +44,7 @@ metadata:
     provi.repository: https://github.com/example/repo
   labels:
     app: worker
-    chart: defaults
+    chart: my-cool-app
     chartVersion: 1.0.0
     team: cool-team
 spec:
@@ -54,15 +54,15 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      selector: defaults-statefulset-worker
+      selector: my-cool-app-statefulset-worker
   template:
     metadata:
       annotations:
         provi.repository: https://github.com/example/repo
       labels:
-        selector: defaults-statefulset-worker
+        selector: my-cool-app-statefulset-worker
         app: worker
-        chart: defaults
+        chart: my-cool-app
         chartVersion: 1.0.0
         team: cool-team
     spec:

--- a/test/fixtures/Chart.lock
+++ b/test/fixtures/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.7
-digest: sha256:9cc33c986f74796976839313cba76a8d431de6edc89ec6d22e9d75aa2d5aca27
-generated: "2024-12-23T13:14:23.492561-05:00"
+  version: 1.8.8
+digest: sha256:70b1f2648a660ec5bb3adea1161dd333104cdbf3845f545c4c3d89b4d105680e
+generated: "2025-01-03T13:35:32.223025-06:00"

--- a/test/fixtures/Chart.yaml
+++ b/test/fixtures/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-name: defaults
+name: my-cool-app
 description: Defaults chart for testing
 type: application
 version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.7"
+    version: "1.8.8"

--- a/test/fixtures/deployments/values-pdb-maxUnavailable.yaml
+++ b/test/fixtures/deployments/values-pdb-maxUnavailable.yaml
@@ -1,0 +1,61 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+  labels:
+    team: cool-team
+  appDomain: test-app-domain
+  serviceAccount:
+    name: test-deployments
+  env:
+    RAILS_ENV: staging
+
+deployments:
+  web:
+    annotations:
+      test.override.annotation: hello-override-world
+    labels:
+      testOverrideLabel: hello-override-world
+    service:
+      ports:
+        http:
+          port: 8080
+          targetPort: 8080
+          protocol: TCP
+    serviceAccount:
+      enabled: true
+    replicas: 3
+    autoscaling:
+      minReplicas: 3
+      maxReplicas: 6
+    podDisruptionBudget:
+      maxUnavailable: 2
+    pod:
+      affinity:
+        type: karpenter
+      topologySpreadConstraints:
+        enabled: true
+        matchLabels:
+          app.kubernetes.io/name: test-deployments
+      containers:
+        app:
+          envFrom:
+            - secretRef:
+                name: test-deployments
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m
+              ephemeral-storage: 200Mi
+            limits:
+              memory: 256Mi
+              ephemeral-storage: 200Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+          readinessProbe:
+            disabled: true
+      tolerations:
+        - spot

--- a/test/fixtures/deployments/values-pdb-minAvailPercent.yaml
+++ b/test/fixtures/deployments/values-pdb-minAvailPercent.yaml
@@ -1,0 +1,61 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+  labels:
+    team: cool-team
+  appDomain: test-app-domain
+  serviceAccount:
+    name: test-deployments
+  env:
+    RAILS_ENV: staging
+
+deployments:
+  web:
+    annotations:
+      test.override.annotation: hello-override-world
+    labels:
+      testOverrideLabel: hello-override-world
+    service:
+      ports:
+        http:
+          port: 8080
+          targetPort: 8080
+          protocol: TCP
+    serviceAccount:
+      enabled: true
+    replicas: 3
+    autoscaling:
+      minReplicas: 3
+      maxReplicas: 6
+    podDisruptionBudget:
+      minAvailable: "25%"
+    pod:
+      affinity:
+        type: karpenter
+      topologySpreadConstraints:
+        enabled: true
+        matchLabels:
+          app.kubernetes.io/name: test-deployments
+      containers:
+        app:
+          envFrom:
+            - secretRef:
+                name: test-deployments
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m
+              ephemeral-storage: 200Mi
+            limits:
+              memory: 256Mi
+              ephemeral-storage: 200Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+          readinessProbe:
+            disabled: true
+      tolerations:
+        - spot

--- a/test/fixtures/deployments/values-pdb-minAvailable.yaml
+++ b/test/fixtures/deployments/values-pdb-minAvailable.yaml
@@ -1,0 +1,61 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+  labels:
+    team: cool-team
+  appDomain: test-app-domain
+  serviceAccount:
+    name: test-deployments
+  env:
+    RAILS_ENV: staging
+
+deployments:
+  web:
+    annotations:
+      test.override.annotation: hello-override-world
+    labels:
+      testOverrideLabel: hello-override-world
+    service:
+      ports:
+        http:
+          port: 8080
+          targetPort: 8080
+          protocol: TCP
+    serviceAccount:
+      enabled: true
+    replicas: 3
+    autoscaling:
+      minReplicas: 3
+      maxReplicas: 6
+    podDisruptionBudget:
+      minAvailable: 1
+    pod:
+      affinity:
+        type: karpenter
+      topologySpreadConstraints:
+        enabled: true
+        matchLabels:
+          app.kubernetes.io/name: test-deployments
+      containers:
+        app:
+          envFrom:
+            - secretRef:
+                name: test-deployments
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m
+              ephemeral-storage: 200Mi
+            limits:
+              memory: 256Mi
+              ephemeral-storage: 200Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+          readinessProbe:
+            disabled: true
+      tolerations:
+        - spot

--- a/test/test_deployments.bats
+++ b/test/test_deployments.bats
@@ -61,3 +61,26 @@ teardown() {
   assert_output --partial 'key: rds!cluster-1a123b45-6c78-901d-e234-f5678901a23b'
   assert_output --partial 'secretKey: MY_COOL_SECRET_1'
 }
+
+# bats test_tags=tag:pdb-min-available
+@test "deployments: renders podDisruptionBudget if included" {
+  run helm template -f test/fixtures/deployments/values-pdb-minAvailable.yaml test/fixtures/deployments/
+  assert_output --partial 'kind: PodDisruptionBudget'
+  assert_output --partial 'name: my-cool-app-web-pdb'
+  assert_output --partial 'app: my-cool-app-deployment-web'
+  assert_output --partial 'minAvailable: 1' 
+}
+
+# bats test_tags=tag:pdb-max-unavailable
+@test "deployments: renders podDisruptionBudget with maxUnavailable" {
+  run helm template -f test/fixtures/deployments/values-pdb-maxUnavailable.yaml test/fixtures/deployments/
+  assert_output --partial 'kind: PodDisruptionBudget'
+  assert_output --partial 'maxUnavailable: 2' 
+}
+
+# bats test_tags=tag:pdb-min-avail-percent
+@test "deployments: renders podDisruptionBudget with minAvailable as a percentage" {
+  run helm template -f test/fixtures/deployments/values-pdb-minAvailPercent.yaml test/fixtures/deployments/
+  assert_output --partial 'kind: PodDisruptionBudget'
+  assert_output --partial 'minAvailable: 25%' 
+}


### PR DESCRIPTION
Adds the ability to define Pod Disruption Budgets to a deployment per the [kubernetes
docs](https://kubernetes.io/docs/tasks/run-application/configure-pdb/).

Also updates the Chart name to something more descriptive than `defaults` (hopefully encouraging users to pick something appropriate).