### PR TITLE
Add option for services to redirect a base domain to www. for ALB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.9] - 2025-01-10
+
+### Added
+
+- A service can specify that its base domain should redirect to a www. domain by adding the `redirectHostToWWW` key with the base domain as the value. e.g. if your hostnames list includes www.example.com you can specify `redirectHostToWWW: example.com` in order to set the ALB rules to do this. At the moment this is only supported for one hostname per service definition.
+
 ## [1.8.8] - 2025-01-03
 
 ### Added

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.8.8
+version: 1.8.9
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_ingress.yaml.tpl
+++ b/charts/common/templates/_ingress.yaml.tpl
@@ -91,7 +91,7 @@
 {{- $wwwRedirect := "" }}
 {{- if hasKey $v "redirectHostToWWW" }}
   {{- if ne $v.ingressClass "alb" }}
-    {{- $_ := required (printf "www redirect is only supported for ALB ingresses") $appDomain }}
+    {{- $_ := required (printf "www redirect is only supported for ALB ingresses") }}
   {{- end }}
   {{- $wwwRedirect = printf "www.%s" $v.redirectHostToWWW }}
   {{- if $v.imperva }}

--- a/test/fixtures/Chart.lock
+++ b/test/fixtures/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.8
-digest: sha256:70b1f2648a660ec5bb3adea1161dd333104cdbf3845f545c4c3d89b4d105680e
-generated: "2025-01-03T13:35:32.223025-06:00"
+  version: 1.8.9
+digest: sha256:1a11fa30499ad830bd5aefc1258d5681fdf662062d3ab69e3ec5d1b5c6c4d5b5
+generated: "2025-01-10T14:56:56.181732-05:00"

--- a/test/fixtures/Chart.yaml
+++ b/test/fixtures/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.8"
+    version: "1.8.9"

--- a/test/fixtures/ingresses/values-redirect-to-www.yaml
+++ b/test/fixtures/ingresses/values-redirect-to-www.yaml
@@ -1,0 +1,21 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+    provi.slack: my-cool-team
+  labels:
+    team: cool-team
+
+ingresses:
+  dummy:
+    service:
+      port: 8080
+      name: web
+    scheme: internet-facing
+    ingressClass: "alb"
+    hostnames:
+      - subdomain.example.com
+      - www.example.com
+    redirectHostToWWW: example.com
+    certificateArn: "arn:aws:acm:us-east-2:123456789:certificate/abcd1234-1a2b-3c4d-5e6f-987654abcd123"


### PR DESCRIPTION
Adds a redirectHostToWWW option which takes the base domain to apply a www redirect to and creates the relevant ALB annotations.

This option seems a little overly specific and like it could be a map allowing arbitrary redirects to any of a service's hostnames, but went with this since our only existing use case is for redirecting sevenfifty.com domains to www and to avoid adding a lot of extra go template code that might not be used.