### PR TITLE
DEVOPS-3236 remove ttl from alb ingresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.10] - 2025-04-28
+
+### Fixed
+
+- ALB Ingresses which have the `ttl` annotation (`external-dns.alpha.kubernetes.io/ttl`) will keep triggering external-dns to modify the records, but nothing actually happens, which is a waste of resources and adds unnecessary logging.
+
 ## [1.8.9] - 2025-01-10
 
 ### Added

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.8.9
+version: 1.8.10
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_ingress.yaml.tpl
+++ b/charts/common/templates/_ingress.yaml.tpl
@@ -106,7 +106,9 @@ metadata:
   name: {{ $k }}
   annotations:
     {{- toYaml $finalAnnotations | nindent 4}}
+    {{- if ne $v.ingressClass "alb" }}
     external-dns.alpha.kubernetes.io/ttl: "10"
+    {{- end }}
     {{- if and (hasKey $.root.Values "spec" ) (hasKey $.root.Values.spec "ingress") }}
     {{- if (hasKey $.root.Values.spec.ingress "route53_weight") }}
     external-dns.alpha.kubernetes.io/aws-weight: "{{ $.root.Values.spec.ingress.route53_weight }}"

--- a/test/expected_output/ingresses-alb.yaml
+++ b/test/expected_output/ingresses-alb.yaml
@@ -18,7 +18,6 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
     provi.repository: https://github.com/example/repo
     provi.slack: my-cool-team
-    external-dns.alpha.kubernetes.io/ttl: "10"
   labels:
     chart: my-cool-app
     chartVersion: 1.0.0

--- a/test/fixtures/Chart.lock
+++ b/test/fixtures/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.9
-digest: sha256:1a11fa30499ad830bd5aefc1258d5681fdf662062d3ab69e3ec5d1b5c6c4d5b5
-generated: "2025-01-10T14:56:56.181732-05:00"
+  version: 1.8.10
+digest: sha256:5c2b200bbb4249e60460b9819c53a2b0aed75121efd63230d6c30072c5287690
+generated: "2025-04-28T10:35:06.013118-05:00"

--- a/test/fixtures/Chart.yaml
+++ b/test/fixtures/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.9"
+    version: "1.8.10"


### PR DESCRIPTION
The `ttl` annotation causes `external-dns` to keep trying to modify the DNS record for ALBs with that annotation, but it's a no-op. This results in noise in the logs which makes them harder to read and wastes resources.

This will fix it.