### PR TITLE
DEVOPS-3602 fix PDB selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.11] - 2025-06-12
+
+### Fixed
+
+- The Pod Disruption Template used `app` as the matchLabels selector, but the selector used by Deployments and all the various resources is `selector`. This aligns PDBs with the rest of the resources.
+
 ## [1.8.10] - 2025-04-28
 
 ### Fixed

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.8.10
+version: 1.8.11
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_pod_disruption_budget.yaml.tpl
+++ b/charts/common/templates/_pod_disruption_budget.yaml.tpl
@@ -13,5 +13,5 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-      app: {{ .selector }}
+      selector: {{ .selector }}
 {{- end }}

--- a/test/fixtures/Chart.lock
+++ b/test/fixtures/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.10
-digest: sha256:5c2b200bbb4249e60460b9819c53a2b0aed75121efd63230d6c30072c5287690
-generated: "2025-04-28T10:35:06.013118-05:00"
+  version: 1.8.11
+digest: sha256:4fe74fe2679fb4f0f3bd4220c47ac915af93407948724f4c5c4d94302955efeb
+generated: "2025-06-12T10:41:21.573804-05:00"

--- a/test/fixtures/Chart.yaml
+++ b/test/fixtures/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.10"
+    version: "1.8.11"

--- a/test/test_deployments.bats
+++ b/test/test_deployments.bats
@@ -67,7 +67,7 @@ teardown() {
   run helm template -f test/fixtures/deployments/values-pdb-minAvailable.yaml test/fixtures/deployments/
   assert_output --partial 'kind: PodDisruptionBudget'
   assert_output --partial 'name: my-cool-app-web-pdb'
-  assert_output --partial 'app: my-cool-app-deployment-web'
+  assert_output --partial 'selector: my-cool-app-deployment-web'
   assert_output --partial 'minAvailable: 1' 
 }
 


### PR DESCRIPTION
The Pod Disruption Template used `app` as the matchLabels selector, but the selector used by Deployments and all the various resources is `selector`.

This aligns PDBs with the rest of the resources.