### PR TITLE
DEVOPS-3604 fix rendering bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.12] - 2025-06-12
+
+### Fixed
+
+- If there are multiple deployments defined and the second (or any subsequent after the first) deployment has a `podDisruptionBudget` defined, then the template does not put a newline after each deployment, thereby not creating a separate document (because there needs to be a `---` on its own line in Yaml to separate documents), and thereby causing less than all of your deployments to be created.
+
 ## [1.8.11] - 2025-06-12
 
 ### Fixed

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.8.11
+version: 1.8.12
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_pod_disruption_budget.yaml.tpl
+++ b/charts/common/templates/_pod_disruption_budget.yaml.tpl
@@ -1,4 +1,4 @@
-{{- define "common.kubernetes.pod_disruption_budget" -}}
+{{- define "common.kubernetes.pod_disruption_budget" }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/test/fixtures/Chart.lock
+++ b/test/fixtures/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.11
-digest: sha256:4fe74fe2679fb4f0f3bd4220c47ac915af93407948724f4c5c4d94302955efeb
-generated: "2025-06-12T10:41:21.573804-05:00"
+  version: 1.8.12
+digest: sha256:c4b0fb4875c06c1d8cac56e2c69328fd7647ac4ee8889e643128630781afbfa2
+generated: "2025-06-12T12:09:12.231293-05:00"

--- a/test/fixtures/Chart.yaml
+++ b/test/fixtures/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.11"
+    version: "1.8.12"

--- a/test/fixtures/deployments/values-multiple-deployments.yaml
+++ b/test/fixtures/deployments/values-multiple-deployments.yaml
@@ -1,0 +1,119 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+  labels:
+    team: cool-team
+  appDomain: test-app-domain
+  serviceAccount:
+    name: test-deployments
+  env:
+    RAILS_ENV: staging
+
+deployments:
+  web:
+    # default is RollingUpdate
+    strategy: Recreate
+    annotations:
+      test.override.annotation: hello-override-world
+    labels:
+      testOverrideLabel: hello-override-world
+    service:
+      ports:
+        http:
+          port: 8080
+          targetPort: 8080
+          protocol: TCP
+    serviceAccount:
+      enabled: true
+    replicas: 3
+    autoscaling:
+      minReplicas: 3
+      maxReplicas: 6
+    pod:
+      affinity:
+        type: karpenter
+      topologySpreadConstraints:
+        enabled: true
+        matchLabels:
+          app.kubernetes.io/name: test-deployments
+      containers:
+        app:
+          envFrom:
+            - secretRef:
+                name: test-deployments
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m
+              ephemeral-storage: 200Mi
+            limits:
+              memory: 256Mi
+              ephemeral-storage: 200Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+          readinessProbe:
+            disabled: true
+      tolerations:
+        - spot
+  worker:
+    serviceAccount:
+      enabled: true
+    replicas: 1
+    pod:
+      affinity:
+        type: karpenter
+      topologySpreadConstraints:
+        enabled: true
+        matchLabels:
+          app.kubernetes.io/name: test-worker
+      containers:
+        app:
+          envFrom:
+            - secretRef:
+                name: test-deployments
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m
+              ephemeral-storage: 200Mi
+            limits:
+              memory: 256Mi
+              ephemeral-storage: 200Mi
+          livenessProbe:
+            disabled: true
+          readinessProbe:
+            disabled: true
+  worker2:
+    serviceAccount:
+      enabled: true
+    replicas: 1
+    podDisruptionBudget:
+      maxUnavailable: 0
+    pod:
+      affinity:
+        type: karpenter
+      topologySpreadConstraints:
+        enabled: true
+        matchLabels:
+          app.kubernetes.io/name: test-worker
+      containers:
+        app:
+          envFrom:
+            - secretRef:
+                name: test-deployments
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m
+              ephemeral-storage: 200Mi
+            limits:
+              memory: 256Mi
+              ephemeral-storage: 200Mi
+          livenessProbe:
+            disabled: true
+          readinessProbe:
+            disabled: true

--- a/test/test_deployments.bats
+++ b/test/test_deployments.bats
@@ -84,3 +84,9 @@ teardown() {
   assert_output --partial 'kind: PodDisruptionBudget'
   assert_output --partial 'minAvailable: 25%' 
 }
+
+# bats test_tags=tag:pdb-multi-deployment-rendering
+@test "deployments: ensures a separate document between all deployments when PDBs are defined" {
+  run helm template -f test/fixtures/deployments/values-multiple-deployments.yaml test/fixtures/deployments/
+  refute_output --partial 'karpenter---'
+}


### PR DESCRIPTION
I found a bug in the helm-charts where if:

there are multiple deployments

the second (or any subsequent after the first) deployment has a podDisruptionBudget defined

then the template does not put a newline after each deployment, thereby not creating a separate document (because there needs to be a --- on its own line in Yaml to separate documents), and thereby causing less than all of your deployments to be created.