### PR TITLE
DEVOPS-3707 remove PreSync annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.13] - 2025-07-17
+
+### Fixed
+
+- Removes the `argocd.argoproj.io/hook: PreSync` annotation from the cluster-scoped `ClusterExternalSecret` manifests, since it can cause errors rendering the JSON used internally by ArgoCD.
+
 ## [1.8.12] - 2025-06-12
 
 ### Fixed

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.8.12
+version: 1.8.13
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_clusterexternalsecret.yaml.tpl
+++ b/charts/common/templates/_clusterexternalsecret.yaml.tpl
@@ -10,7 +10,6 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "-2"
-    argocd.argoproj.io/hook: PreSync
 spec:
   namespaceSelector:
     matchLabels:

--- a/test/expected_output/clusterexternalsecret-basic.yaml
+++ b/test/expected_output/clusterexternalsecret-basic.yaml
@@ -9,7 +9,6 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "-2"
-    argocd.argoproj.io/hook: PreSync
 spec:
   namespaceSelector:
     matchLabels:
@@ -47,7 +46,6 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "-2"
-    argocd.argoproj.io/hook: PreSync
 spec:
   namespaceSelector:
     matchLabels:

--- a/test/fixtures/Chart.lock
+++ b/test/fixtures/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.12
-digest: sha256:c4b0fb4875c06c1d8cac56e2c69328fd7647ac4ee8889e643128630781afbfa2
-generated: "2025-06-12T12:09:12.231293-05:00"
+  version: 1.8.13
+digest: sha256:71261c8474316d62b11c0eb7ae12dbfbc2612fdd3d408fa8803f8f18211dc37e
+generated: "2025-07-17T14:47:40.803494-05:00"

--- a/test/fixtures/Chart.yaml
+++ b/test/fixtures/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.12"
+    version: "1.8.13"

--- a/test/test_clusterexternalsecret.bats
+++ b/test/test_clusterexternalsecret.bats
@@ -18,7 +18,7 @@ teardown() {
   run helm template -f test/fixtures/clusterexternalsecret/values-basic.yaml test/fixtures/clusterexternalsecret/
   assert_output --partial 'kind: ClusterExternalSecret'
   assert_output --partial 'helm.sh/hook: pre-install,pre-upgrade'
-  assert_output --partial 'argocd.argoproj.io/hook: PreSync'
+  refute_output --partial 'argocd.argoproj.io/hook: PreSync'
 }
 
 # bats test_tags=tag:basic


### PR DESCRIPTION
I'mn hoping this will fix `Unknown` status for `search-service-admin`. ChatGPT says:

ArgoCD hooks are best used with namespaced resources, because:

ArgoCD tracks resources under .status.resources[], which expects to resolve:

```
{
    "kind": "ClusterExternalSecret",
      "namespace": "...",
        "name": "search-service",
          ...
}
```

When you apply argocd.argoproj.io/hook to a cluster-scoped resource, the namespace field will be "", which causes ArgoCD to generate an invalid internal representation, specifically in the JSON patch sent to Kubernetes.

This corrupts .status.resources and causes errors like:

```
Error constructing app status patch: unable to find api field in struct
RawExtension for the json field "spec"
```