### PR TITLE
DEVOPS-3785 add helm dep update to script

### DIFF
--- a/scripts/make-upgrade-prs.sh
+++ b/scripts/make-upgrade-prs.sh
@@ -177,14 +177,16 @@ function main() {
           if [ "${DRY_RUN}" == "true" ]; then
             echo "   DRY_RUN: new file contents:"
             yq -e ".dependencies[0].version = \"${TO_VERSION}\"" "$CHART"
+            echo "   DRY_RUN: would have run: helm dep up $(dirname $CHART)"
           else
             yq -e -i ".dependencies[0].version = \"${TO_VERSION}\"" "$CHART"
+            helm dep up $(dirname "$CHART")
           fi
 
           if [ "${DRY_RUN}" == "true" ]; then
-            echo "   DRY_RUN: would have git-added ${CHART}'
+            echo "   DRY_RUN: would have git-added ${CHART} and possibly the lockfile"
           else
-            git add "$CHART"
+            git add .
           fi
           UPDATED=true
           break


### PR DESCRIPTION
This ensures that, if a repo doesn't ignore Chart.lock, then it gets updated accordingly with the Chart.yaml.