### PR TITLE
INFRASEC-3856 use data from instead of hard coded keys to build secrets contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.16] - 2026-01-30
+
+### Changed
+
+- When one omits the `secretKeys` mapping from a secret in the `secrets:` section, the `external-secrets` controller will extract all the key/value pairs from the AWS Secretsmanager secret. This avoids the problem of forgetting to include one of the keys when defining the secret, or when adding or removing keys in the Secretsmanager secret.
+
 ## [1.8.15] - 2025-12-17
 
 ### Added

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.8.15
+version: 1.8.16
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_clusterexternalsecret.yaml.tpl
+++ b/charts/common/templates/_clusterexternalsecret.yaml.tpl
@@ -24,6 +24,7 @@ spec:
     target:
       name: {{ .k8sSecretName }}
       creationPolicy: Owner
+    {{- if and .secretKeys (gt (len .secretKeys) 0) }}
     data:
     {{- range $secretKey := .secretKeys }}
     - secretKey: {{ $secretKey }}
@@ -33,6 +34,11 @@ spec:
         key: {{ $secretDetails.awsSecretName }}
         property: {{ $secretKey }}
     {{- end }}
+    {{- else }}
+    dataFrom:
+    - extract:
+        key: {{ $secretDetails.awsSecretName }}
+    {{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/test/expected_output/clusterexternalsecret-datafrom.yaml
+++ b/test/expected_output/clusterexternalsecret-datafrom.yaml
@@ -1,0 +1,55 @@
+
+---
+# Source: my-cool-app/templates/microservice.yaml.tpl
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterExternalSecret
+metadata:
+  name: mycooldb
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-2"
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: mycoolservice
+  refreshTime: 1m
+
+  externalSecretSpec:
+    refreshInterval: 1h
+    secretStoreRef:
+      name: aws-store
+      kind: ClusterSecretStore
+    target:
+      name: mycooldb
+      creationPolicy: Owner
+    dataFrom:
+    - extract:
+        key: rds!cluster-1a123b45-6c78-901d-e234-f5678901a23b
+---
+# Source: my-cool-app/templates/microservice.yaml.tpl
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterExternalSecret
+metadata:
+  name: mycoolservice
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-2"
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: mycoolservice
+  refreshTime: 1m
+
+  externalSecretSpec:
+    refreshInterval: 1h
+    secretStoreRef:
+      name: aws-store
+      kind: ClusterSecretStore
+    target:
+      name: mycoolservice
+      creationPolicy: Owner
+    dataFrom:
+    - extract:
+        key: mycoolservice

--- a/test/fixtures/affinity/Chart.lock
+++ b/test/fixtures/affinity/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.15
-digest: sha256:3896fdc1110d8bc821238b59ff864e942d04e6149a4d08a9adf338d9e5e7b157
-generated: "2025-12-17T14:16:44.25493-05:00"
+  version: 1.8.16
+digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
+generated: "2026-01-30T10:54:40.522505-06:00"

--- a/test/fixtures/affinity/Chart.yaml
+++ b/test/fixtures/affinity/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.15"
+    version: "1.8.16"

--- a/test/fixtures/autoscaler/Chart.lock
+++ b/test/fixtures/autoscaler/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.15
-digest: sha256:3896fdc1110d8bc821238b59ff864e942d04e6149a4d08a9adf338d9e5e7b157
-generated: "2025-12-17T14:16:44.590549-05:00"
+  version: 1.8.16
+digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
+generated: "2026-01-30T10:54:41.183645-06:00"

--- a/test/fixtures/autoscaler/Chart.yaml
+++ b/test/fixtures/autoscaler/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.15"
+    version: "1.8.16"

--- a/test/fixtures/clusterexternalsecret/Chart.lock
+++ b/test/fixtures/clusterexternalsecret/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.15
-digest: sha256:3896fdc1110d8bc821238b59ff864e942d04e6149a4d08a9adf338d9e5e7b157
-generated: "2025-12-17T14:16:44.898013-05:00"
+  version: 1.8.16
+digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
+generated: "2026-01-30T10:54:43.299398-06:00"

--- a/test/fixtures/clusterexternalsecret/Chart.yaml
+++ b/test/fixtures/clusterexternalsecret/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.15"
+    version: "1.8.16"

--- a/test/fixtures/clusterexternalsecret/values-datafrom.yaml
+++ b/test/fixtures/clusterexternalsecret/values-datafrom.yaml
@@ -1,0 +1,25 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+  labels:
+    team: cool-team
+
+secrets:
+  mycoolservice:
+    k8sSecretName: mycoolservice
+    awsSecretName: mycoolservice
+    namespace: mycoolservice
+    refreshTime: "1m"
+    refreshInterval: "1h"
+    secretStoreRef:
+      name: "aws-store"
+  mycooldb:
+    k8sSecretName: mycooldb
+    awsSecretName: 'rds!cluster-1a123b45-6c78-901d-e234-f5678901a23b'
+    namespace: mycoolservice
+    refreshTime: "1m"
+    refreshInterval: "1h"
+    secretStoreRef:
+      name: "aws-store"

--- a/test/fixtures/configmaps/Chart.lock
+++ b/test/fixtures/configmaps/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.15
-digest: sha256:3896fdc1110d8bc821238b59ff864e942d04e6149a4d08a9adf338d9e5e7b157
-generated: "2025-12-17T14:16:45.197932-05:00"
+  version: 1.8.16
+digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
+generated: "2026-01-30T10:54:44.049709-06:00"

--- a/test/fixtures/configmaps/Chart.yaml
+++ b/test/fixtures/configmaps/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.15"
+    version: "1.8.16"

--- a/test/fixtures/containers/Chart.lock
+++ b/test/fixtures/containers/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.15
-digest: sha256:3896fdc1110d8bc821238b59ff864e942d04e6149a4d08a9adf338d9e5e7b157
-generated: "2025-12-17T14:16:45.531425-05:00"
+  version: 1.8.16
+digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
+generated: "2026-01-30T10:54:44.861017-06:00"

--- a/test/fixtures/containers/Chart.yaml
+++ b/test/fixtures/containers/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.15"
+    version: "1.8.16"

--- a/test/fixtures/cronjobs/Chart.lock
+++ b/test/fixtures/cronjobs/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.15
-digest: sha256:3896fdc1110d8bc821238b59ff864e942d04e6149a4d08a9adf338d9e5e7b157
-generated: "2025-12-17T14:16:45.830106-05:00"
+  version: 1.8.16
+digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
+generated: "2026-01-30T10:54:45.542165-06:00"

--- a/test/fixtures/cronjobs/Chart.yaml
+++ b/test/fixtures/cronjobs/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.15"
+    version: "1.8.16"

--- a/test/fixtures/deployments/Chart.lock
+++ b/test/fixtures/deployments/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.15
-digest: sha256:3896fdc1110d8bc821238b59ff864e942d04e6149a4d08a9adf338d9e5e7b157
-generated: "2025-12-17T14:16:46.156301-05:00"
+  version: 1.8.16
+digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
+generated: "2026-01-30T10:54:46.236457-06:00"

--- a/test/fixtures/deployments/Chart.yaml
+++ b/test/fixtures/deployments/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.15"
+    version: "1.8.16"

--- a/test/fixtures/ingresses/Chart.lock
+++ b/test/fixtures/ingresses/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.15
-digest: sha256:3896fdc1110d8bc821238b59ff864e942d04e6149a4d08a9adf338d9e5e7b157
-generated: "2025-12-17T14:16:46.476756-05:00"
+  version: 1.8.16
+digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
+generated: "2026-01-30T10:54:47.171654-06:00"

--- a/test/fixtures/ingresses/Chart.yaml
+++ b/test/fixtures/ingresses/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.15"
+    version: "1.8.16"

--- a/test/fixtures/jobs/Chart.lock
+++ b/test/fixtures/jobs/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.15
-digest: sha256:3896fdc1110d8bc821238b59ff864e942d04e6149a4d08a9adf338d9e5e7b157
-generated: "2025-12-17T14:16:46.79402-05:00"
+  version: 1.8.16
+digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
+generated: "2026-01-30T10:54:50.306062-06:00"

--- a/test/fixtures/jobs/Chart.yaml
+++ b/test/fixtures/jobs/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.15"
+    version: "1.8.16"

--- a/test/fixtures/microservice/Chart.lock
+++ b/test/fixtures/microservice/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.15
-digest: sha256:3896fdc1110d8bc821238b59ff864e942d04e6149a4d08a9adf338d9e5e7b157
-generated: "2025-12-17T14:16:47.111775-05:00"
+  version: 1.8.16
+digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
+generated: "2026-01-30T10:54:52.555235-06:00"

--- a/test/fixtures/microservice/Chart.yaml
+++ b/test/fixtures/microservice/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.15"
+    version: "1.8.16"

--- a/test/fixtures/podspec/Chart.lock
+++ b/test/fixtures/podspec/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.15
-digest: sha256:3896fdc1110d8bc821238b59ff864e942d04e6149a4d08a9adf338d9e5e7b157
-generated: "2025-12-17T14:16:47.429932-05:00"
+  version: 1.8.16
+digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
+generated: "2026-01-30T10:54:53.237483-06:00"

--- a/test/fixtures/podspec/Chart.yaml
+++ b/test/fixtures/podspec/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.15"
+    version: "1.8.16"

--- a/test/fixtures/statefulsets/Chart.lock
+++ b/test/fixtures/statefulsets/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.15
-digest: sha256:3896fdc1110d8bc821238b59ff864e942d04e6149a4d08a9adf338d9e5e7b157
-generated: "2025-12-17T14:16:47.7213-05:00"
+  version: 1.8.16
+digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
+generated: "2026-01-30T10:54:53.910854-06:00"

--- a/test/fixtures/statefulsets/Chart.yaml
+++ b/test/fixtures/statefulsets/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.15"
+    version: "1.8.16"

--- a/test/test_clusterexternalsecret.bats
+++ b/test/test_clusterexternalsecret.bats
@@ -31,3 +31,17 @@ teardown() {
   assert_success
   assert_output --partial 'apiVersion: external-secrets.io/v1'
 }
+#
+# bats test_tags=tag:datafrom
+@test "clusterexternalsecret: if secretKeys are not defined, use all keys from the secret (via dataFrom)" {
+  run helm template -f test/fixtures/clusterexternalsecret/values-datafrom.yaml test/fixtures/clusterexternalsecret/
+  assert_success
+  assert_output --partial 'dataFrom:'
+}
+
+
+# bats test_tags=tag:datafrom
+@test "clusterexternalsecret: if secretKeys are not defined, matches expected output" {
+  helm template -f test/fixtures/clusterexternalsecret/values-datafrom.yaml test/fixtures/clusterexternalsecret/ > "$TEST_TEMP_DIR/default_output.yaml"
+  assert diff -ub test/expected_output/clusterexternalsecret-datafrom.yaml "$TEST_TEMP_DIR/default_output.yaml"
+}


### PR DESCRIPTION
We frequently run into problems when there is a disconnect between the
secret keys in the AWS Secretsmanager and what is defined in the Helm
chart for an appplication. AWS secrets can have multiple key/value
entries (called "keys") per secret.

As currently configured, we would have to include every key we desired
to expose in the Helm chart. With the changes in this PR, we no longer
have to ennumerate every key; we can simply omit the `secretKeys`
mapping, and all of the key/value entries from the AWS secret will be
synced to the Kubernetes secret created by the controller.

See "dataFrom" in: https://external-secrets.io/v1.3.1/api/externalsecret/