### PR TITLE
INFRASEC-4510 Decommission maitred service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- INFRASEC-4510: maitred service decommissioned (workloads removed from provi-eks-workloads).
+
 ## [1.8.16] - 2026-01-30
 
 ### Changed

--- a/scripts/make-upgrade-prs.sh
+++ b/scripts/make-upgrade-prs.sh
@@ -35,7 +35,6 @@ REPOS=(
   "forklift"
   "happy-hour"
   "happy-hour-validation-service"
-  "maitred"
   "nysla"
   "pallet"
   "provi-devops"


### PR DESCRIPTION
## INFRASEC-4510 Decommission maitred service

- Remove maitred from `scripts/make-upgrade-prs.sh` REPOS list
- Document decommission in CHANGELOG

Workloads removed in [provi-eks-workloads](https://github.com/Provi-Engineering/provi-eks-workloads/pull/155).

Made with [Cursor](https://cursor.com)