### PR TITLE
ci: fix security job to use update-fixture-charts.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,11 +45,15 @@ jobs:
           apt-get -y install curl
           curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
+      - name: Prepare fixture dependencies
+        run: |
+          COMMON_VERSION=$(awk -F': ' '/^version:/ {print $2}' charts/common/Chart.yaml)
+          bash scripts/update-fixture-charts.sh "$COMMON_VERSION"
+
       - name: Snyk IAC test
         env:
           SNYK_TOKEN : ${{ secrets.SNYK_TOKEN }}
         run: |
-          helm dependency update ./test/fixtures/microservice/
           helm template -f ./test/fixtures/microservice/values-basic.yaml ./test/fixtures/microservice/ > ./output.yaml
           snyk iac test ./output.yaml
 


### PR DESCRIPTION
## Summary
- The security job in `release.yml` was doing a raw `helm dependency update` against the committed fixture `Chart.yaml`, which still referenced the previous chart version (1.8.16). This caused the 1.8.17 release to fail.
- Adds the same `update-fixture-charts.sh` step that the `test` job already uses, so fixture charts always reflect the current common chart version.

## Context
The 1.8.17 release (defaulting `ClusterExternalSecret` to `external-secrets.io/v1`) has been stuck since March 31 because of this CI bug. We need this version published to avoid per-app `apiVersion` overrides during the EKS migration.


Made with [Cursor](https://cursor.com)