### PR TITLE
fix(ingress): only add set-identifier when route53_weight is set

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: Common service chart
 name: common
 type: library
-version: 1.8.17
+version: 1.8.18
 maintainers:
   - name: DevOps

--- a/charts/common/templates/_ingress.yaml.tpl
+++ b/charts/common/templates/_ingress.yaml.tpl
@@ -112,10 +112,10 @@ metadata:
     {{- if and (hasKey $.root.Values "spec" ) (hasKey $.root.Values.spec "ingress") }}
     {{- if (hasKey $.root.Values.spec.ingress "route53_weight") }}
     external-dns.alpha.kubernetes.io/aws-weight: "{{ $.root.Values.spec.ingress.route53_weight }}"
-    {{- end }}
-    {{- end }}
-    {{- if and (hasKey $.root.Values "spec" ) (hasKey $.root.Values.spec "clusterName") }}
+    {{- if and (hasKey $.root.Values.spec "clusterName") }}
     external-dns.alpha.kubernetes.io/set-identifier: {{ $.root.Values.spec.clusterName }}
+    {{- end }}
+    {{- end }}
     {{- end }}
     {{- if $wwwRedirect }}
     alb.ingress.kubernetes.io/actions.rule-redirect-www: '{"Type":"redirect","RedirectConfig":{"Host":"www.{{ $v.redirectHostToWWW }}","Port":"443","Protocol":"HTTPS","StatusCode":"HTTP_301"}}'

--- a/test/fixtures/affinity/Chart.lock
+++ b/test/fixtures/affinity/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.16
-digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
-generated: "2026-01-30T10:54:40.522505-06:00"
+  version: 1.8.18
+digest: sha256:cb1abc4a7bfded4b5746b7efab1233add40ec9e51ee119c81044af301a6b225b
+generated: "2026-04-10T16:40:28.069202-05:00"

--- a/test/fixtures/affinity/Chart.yaml
+++ b/test/fixtures/affinity/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.16"
+    version: "1.8.18"

--- a/test/fixtures/autoscaler/Chart.lock
+++ b/test/fixtures/autoscaler/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.16
-digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
-generated: "2026-01-30T10:54:41.183645-06:00"
+  version: 1.8.18
+digest: sha256:cb1abc4a7bfded4b5746b7efab1233add40ec9e51ee119c81044af301a6b225b
+generated: "2026-04-10T16:40:29.739197-05:00"

--- a/test/fixtures/autoscaler/Chart.yaml
+++ b/test/fixtures/autoscaler/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.16"
+    version: "1.8.18"

--- a/test/fixtures/clusterexternalsecret/Chart.lock
+++ b/test/fixtures/clusterexternalsecret/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.16
-digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
-generated: "2026-01-30T10:54:43.299398-06:00"
+  version: 1.8.18
+digest: sha256:cb1abc4a7bfded4b5746b7efab1233add40ec9e51ee119c81044af301a6b225b
+generated: "2026-04-10T16:40:31.375556-05:00"

--- a/test/fixtures/clusterexternalsecret/Chart.yaml
+++ b/test/fixtures/clusterexternalsecret/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.16"
+    version: "1.8.18"

--- a/test/fixtures/configmaps/Chart.lock
+++ b/test/fixtures/configmaps/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.16
-digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
-generated: "2026-01-30T10:54:44.049709-06:00"
+  version: 1.8.18
+digest: sha256:cb1abc4a7bfded4b5746b7efab1233add40ec9e51ee119c81044af301a6b225b
+generated: "2026-04-10T16:40:32.998537-05:00"

--- a/test/fixtures/configmaps/Chart.yaml
+++ b/test/fixtures/configmaps/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.16"
+    version: "1.8.18"

--- a/test/fixtures/containers/Chart.lock
+++ b/test/fixtures/containers/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.16
-digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
-generated: "2026-01-30T10:54:44.861017-06:00"
+  version: 1.8.18
+digest: sha256:cb1abc4a7bfded4b5746b7efab1233add40ec9e51ee119c81044af301a6b225b
+generated: "2026-04-10T16:40:34.614625-05:00"

--- a/test/fixtures/containers/Chart.yaml
+++ b/test/fixtures/containers/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.16"
+    version: "1.8.18"

--- a/test/fixtures/cronjobs/Chart.lock
+++ b/test/fixtures/cronjobs/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.16
-digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
-generated: "2026-01-30T10:54:45.542165-06:00"
+  version: 1.8.18
+digest: sha256:cb1abc4a7bfded4b5746b7efab1233add40ec9e51ee119c81044af301a6b225b
+generated: "2026-04-10T16:40:36.226299-05:00"

--- a/test/fixtures/cronjobs/Chart.yaml
+++ b/test/fixtures/cronjobs/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.16"
+    version: "1.8.18"

--- a/test/fixtures/deployments/Chart.lock
+++ b/test/fixtures/deployments/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.16
-digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
-generated: "2026-01-30T10:54:46.236457-06:00"
+  version: 1.8.18
+digest: sha256:cb1abc4a7bfded4b5746b7efab1233add40ec9e51ee119c81044af301a6b225b
+generated: "2026-04-10T16:40:37.87938-05:00"

--- a/test/fixtures/deployments/Chart.yaml
+++ b/test/fixtures/deployments/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.16"
+    version: "1.8.18"

--- a/test/fixtures/ingresses/Chart.lock
+++ b/test/fixtures/ingresses/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.16
-digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
-generated: "2026-01-30T10:54:47.171654-06:00"
+  version: 1.8.18
+digest: sha256:cb1abc4a7bfded4b5746b7efab1233add40ec9e51ee119c81044af301a6b225b
+generated: "2026-04-10T16:40:39.518437-05:00"

--- a/test/fixtures/ingresses/Chart.yaml
+++ b/test/fixtures/ingresses/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.16"
+    version: "1.8.18"

--- a/test/fixtures/jobs/Chart.lock
+++ b/test/fixtures/jobs/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.16
-digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
-generated: "2026-01-30T10:54:50.306062-06:00"
+  version: 1.8.18
+digest: sha256:cb1abc4a7bfded4b5746b7efab1233add40ec9e51ee119c81044af301a6b225b
+generated: "2026-04-10T16:40:41.902268-05:00"

--- a/test/fixtures/jobs/Chart.yaml
+++ b/test/fixtures/jobs/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.16"
+    version: "1.8.18"

--- a/test/fixtures/microservice/Chart.lock
+++ b/test/fixtures/microservice/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.16
-digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
-generated: "2026-01-30T10:54:52.555235-06:00"
+  version: 1.8.18
+digest: sha256:cb1abc4a7bfded4b5746b7efab1233add40ec9e51ee119c81044af301a6b225b
+generated: "2026-04-10T16:40:44.141238-05:00"

--- a/test/fixtures/microservice/Chart.yaml
+++ b/test/fixtures/microservice/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.16"
+    version: "1.8.18"

--- a/test/fixtures/podspec/Chart.lock
+++ b/test/fixtures/podspec/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.16
-digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
-generated: "2026-01-30T10:54:53.237483-06:00"
+  version: 1.8.18
+digest: sha256:cb1abc4a7bfded4b5746b7efab1233add40ec9e51ee119c81044af301a6b225b
+generated: "2026-04-10T16:40:46.196039-05:00"

--- a/test/fixtures/podspec/Chart.yaml
+++ b/test/fixtures/podspec/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.16"
+    version: "1.8.18"

--- a/test/fixtures/statefulsets/Chart.lock
+++ b/test/fixtures/statefulsets/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../../../charts/common
-  version: 1.8.16
-digest: sha256:59f14e580df4fd9680055bc9bc1b80dc35b8a3089c1e23795da3709d1e42e2de
-generated: "2026-01-30T10:54:53.910854-06:00"
+  version: 1.8.18
+digest: sha256:cb1abc4a7bfded4b5746b7efab1233add40ec9e51ee119c81044af301a6b225b
+generated: "2026-04-10T16:40:47.876998-05:00"

--- a/test/fixtures/statefulsets/Chart.yaml
+++ b/test/fixtures/statefulsets/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: common
     repository: file://../../../charts/common
-    version: "1.8.16"
+    version: "1.8.18"


### PR DESCRIPTION
## Problem

The `external-dns.alpha.kubernetes.io/set-identifier` annotation was unconditionally added to every ingress whenever `spec.clusterName` was set. Route 53 requires a routing policy (weighted, failover, etc.) whenever `SetIdentifier` is present — without one it rejects the entire change batch with:

```
InvalidInput: Invalid request: Expected exactly one of [Weight, Region, Failover, GeoLocation, MultiValueAnswer, GeoProximityLocation, or CidrRoutingConfig], but found none in Change with [Action=CREATE, Name=aaaa-<hostname>, Type=TXT, SetIdentifier=<cluster-name>]
```

This caused external-dns to fail on every sync cycle (consecutive soft errors), blocking all DNS record creation for the affected cluster.

## Fix

Gate `set-identifier` inside the existing `route53_weight` block so both annotations are only emitted together. This matches the intended use case: weighted multi-cluster routing where both a weight and an identifier are required.

## Behaviour

| Scenario | `aws-weight` | `set-identifier` |
|---|---|---|
| `spec.clusterName` set, no `route53_weight` | ✗ | ✗ (fixed) |
| `spec.clusterName` + `route53_weight` set | ✓ | ✓ |


Made with [Cursor](https://cursor.com)