### PR TITLE
REX-2033: ALB ingress-group support + extraPaths for the common ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- REX-2033: ALB ingress-group support — an optional `group:` (`name`, `order`) per ingress emits the `alb.ingress.kubernetes.io/group.name`/`group.order` annotations and makes grouped ingresses share `Name=<group.name>` as their ALB tag (the per-ingress `Name=<key>-alb` tag is a group-level conflict that stops the group from building). Also an optional `extraPaths:` list per ingress (`path`, `pathType` defaulting to `ImplementationSpecific`, `service.name`/`service.port`) rendered ahead of the default `/` path, so one hostname can carve specific paths to one service while another ingress in the group owns the catch-all. Both additive; omitting them renders byte-identical output to before.
+- REX-2033: ALB ingress-group support — an optional `group:` (`name`, `order`) per ingress emits the `alb.ingress.kubernetes.io/group.name`/`group.order` annotations and makes grouped ingresses share `Name=<group.name>` as their ALB tag (the per-ingress `Name=<key>-alb` tag is a group-level conflict that stops the group from building). Also an optional `extraPaths:` list per ingress (`path`, `pathType` defaulting to `ImplementationSpecific`, `service.name`/`service.port`) plus `omitDefaultPath: true` for members that must not own the catch-all. The AWS LBC orders rules by pathType (Exact, then Prefix longest-first, then ImplementationSpecific in manifest order), so when extraPaths are present the default `/` downgrades to `ImplementationSpecific` (still overridable via `pathType`) to keep carved paths ahead of it. All additive; omitting the new keys renders byte-identical output to before.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- REX-2033: ALB ingress-group support — an optional `group:` (`name`, `order`) per ingress emits the `alb.ingress.kubernetes.io/group.name`/`group.order` annotations and makes grouped ingresses share `Name=<group.name>` as their ALB tag (the per-ingress `Name=<key>-alb` tag is a group-level conflict that stops the group from building). Also an optional `extraPaths:` list per ingress (`path`, `pathType` defaulting to `ImplementationSpecific`, `service.name`/`service.port`) rendered ahead of the default `/` path, so one hostname can carve specific paths to one service while another ingress in the group owns the catch-all. Both additive; omitting them renders byte-identical output to before.
+
 ### Removed
 
 - INFRASEC-4510: maitred service decommissioned (workloads removed from provi-eks-workloads).

--- a/charts/common/templates/_ingress.yaml.tpl
+++ b/charts/common/templates/_ingress.yaml.tpl
@@ -25,6 +25,17 @@
 {{- $healthcheckPath := default "/health" $v.healthcheckPath }}
 {{- $healthcheckProtocol := default "HTTP" $v.healthcheckProtocol }}
 {{- $nameTag := printf "Name=%s-alb" $k }}
+{{- /* Ingress groups: members share one ALB. The Name tag is group-level
+       (conflicting tags make the controller refuse to build the group), so
+       grouped ingresses share the group name as their tag. */}}
+{{- with $v.group }}
+{{- $groupName := required (printf "You must specify group.name when group is set for ingress [%v]" $k) .name }}
+{{- $nameTag = printf "Name=%s" $groupName }}
+{{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/group.name" $groupName }}
+{{- if hasKey . "order" }}
+{{- $_ := set $albAnnotations "alb.ingress.kubernetes.io/group.order" (printf "%v" .order) }}
+{{- end }}
+{{- end }}
 {{- $_ := required (printf $certArnErrorMessage $k) $v.certificateArn}}
 {{- $_ := required (printf $schemeErrorMessage $k) $v.scheme}}
 {{- if $v.imperva }}
@@ -130,6 +141,18 @@ spec:
     - host: "{{ $entry }}"
       http:
         paths:
+          {{- /* extraPaths render before the default catch-all: within an
+                 ingress, ALB rule order follows spec order, so specific
+                 paths must precede "/". */}}
+          {{- range $p := $v.extraPaths }}
+          - path: {{ required (printf "You must specify a path for every extraPaths entry of ingress [%v]" $k) $p.path }}
+            pathType: {{ $p.pathType | default "ImplementationSpecific" }}
+            backend:
+              service:
+                name: {{ required (printf "You must specify a service with name and port for every extraPaths entry of ingress [%v]" $k) $p.service.name }}
+                port:
+                  number: {{ required (printf "You must specify a service with name and port for every extraPaths entry of ingress [%v]" $k) $p.service.port }}
+          {{- end }}
           - path: /
             pathType: {{ $v.pathType | default "Prefix" }}
             backend:

--- a/charts/common/templates/_ingress.yaml.tpl
+++ b/charts/common/templates/_ingress.yaml.tpl
@@ -141,9 +141,18 @@ spec:
     - host: "{{ $entry }}"
       http:
         paths:
-          {{- /* extraPaths render before the default catch-all: within an
-                 ingress, ALB rule order follows spec order, so specific
-                 paths must precede "/". */}}
+          {{- /* The AWS LBC (>= v2.4.3) orders rules by pathType — Exact
+                 first, then Prefix (longest first), then
+                 ImplementationSpecific in manifest order — NOT by spec
+                 order. A Prefix "/" therefore outranks every
+                 ImplementationSpecific carve, so when extraPaths are
+                 present the default "/" downgrades to
+                 ImplementationSpecific (rendered last) unless pathType is
+                 set explicitly. A group member that must not own the
+                 catch-all at all sets omitDefaultPath: true. */}}
+          {{- if $v.omitDefaultPath }}
+          {{- $_ := required (printf "omitDefaultPath requires at least one extraPaths entry for ingress [%v]" $k) $v.extraPaths }}
+          {{- end }}
           {{- range $p := $v.extraPaths }}
           - path: {{ required (printf "You must specify a path for every extraPaths entry of ingress [%v]" $k) $p.path }}
             pathType: {{ $p.pathType | default "ImplementationSpecific" }}
@@ -153,13 +162,15 @@ spec:
                 port:
                   number: {{ required (printf "You must specify a service with name and port for every extraPaths entry of ingress [%v]" $k) $p.service.port }}
           {{- end }}
+          {{- if not $v.omitDefaultPath }}
           - path: /
-            pathType: {{ $v.pathType | default "Prefix" }}
+            pathType: {{ $v.pathType | default (ternary "ImplementationSpecific" "Prefix" (not (empty $v.extraPaths))) }}
             backend:
               service:
                 name: {{ $v.service.name }}
                 port:
                   number: {{ $v.service.port }}
+          {{- end }}
       {{- if and $wwwRedirect (eq $wwwRedirect $entry) }}
           - path: /
             pathType: {{ $v.pathType | default "Prefix" }}

--- a/test/expected_output/ingresses-alb-group.yaml
+++ b/test/expected_output/ingresses-alb-group.yaml
@@ -44,13 +44,6 @@ spec:
                 name: web
                 port:
                   number: 8080
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: web
-                port:
-                  number: 8080
 ---
 # Source: my-cool-app/templates/microservice.yaml.tpl
 apiVersion: networking.k8s.io/v1

--- a/test/expected_output/ingresses-alb-group.yaml
+++ b/test/expected_output/ingresses-alb-group.yaml
@@ -1,0 +1,92 @@
+---
+# Source: my-cool-app/templates/microservice.yaml.tpl
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: app
+  annotations:
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:123456789:certificate/abcd1234-1a2b-3c4d-5e6f-987654abcd123
+    alb.ingress.kubernetes.io/group.name: my-cool-group
+    alb.ingress.kubernetes.io/group.order: "10"
+    alb.ingress.kubernetes.io/healthcheck-path: /healthz
+    alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    alb.ingress.kubernetes.io/scheme: internal
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/tags: Name=my-cool-group
+    alb.ingress.kubernetes.io/target-type: ip
+    external-dns.alpha.kubernetes.io/hostname: test-ingresses.example.com
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    provi.repository: https://github.com/example/repo
+    provi.slack: my-cool-team
+  labels:
+    chart: my-cool-app
+    chartVersion: 1.0.0
+    team: cool-team
+spec:
+  ingressClassName: alb
+  rules:
+    - host: "test-ingresses.example.com"
+      http:
+        paths:
+          - path: /api/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: web
+                port:
+                  number: 8080
+          - path: /users/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: web
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web
+                port:
+                  number: 8080
+---
+# Source: my-cool-app/templates/microservice.yaml.tpl
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: static
+  annotations:
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:123456789:certificate/abcd1234-1a2b-3c4d-5e6f-987654abcd123
+    alb.ingress.kubernetes.io/group.name: my-cool-group
+    alb.ingress.kubernetes.io/group.order: "20"
+    alb.ingress.kubernetes.io/healthcheck-path: /_healthz
+    alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    alb.ingress.kubernetes.io/scheme: internal
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/tags: Name=my-cool-group
+    alb.ingress.kubernetes.io/target-type: ip
+    external-dns.alpha.kubernetes.io/hostname: test-ingresses.example.com
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    provi.repository: https://github.com/example/repo
+    provi.slack: my-cool-team
+  labels:
+    chart: my-cool-app
+    chartVersion: 1.0.0
+    team: cool-team
+spec:
+  ingressClassName: alb
+  rules:
+    - host: "test-ingresses.example.com"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: static-web
+                port:
+                  number: 80

--- a/test/fixtures/ingresses/badvalues-alb-group-no-name.yaml
+++ b/test/fixtures/ingresses/badvalues-alb-group-no-name.yaml
@@ -1,0 +1,21 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+    provi.slack: my-cool-team
+  labels:
+    team: cool-team
+
+ingresses:
+  dummy:
+    service:
+      port: 8080
+      name: web
+    scheme: internal
+    ingressClass: "alb"
+    hostnames:
+      - test-ingresses.example.com
+    certificateArn: "arn:aws:acm:us-east-2:123456789:certificate/abcd1234-1a2b-3c4d-5e6f-987654abcd123"
+    group:
+      order: 10

--- a/test/fixtures/ingresses/badvalues-omitdefaultpath-no-extrapaths.yaml
+++ b/test/fixtures/ingresses/badvalues-omitdefaultpath-no-extrapaths.yaml
@@ -1,0 +1,20 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+    provi.slack: my-cool-team
+  labels:
+    team: cool-team
+
+ingresses:
+  dummy:
+    service:
+      port: 8080
+      name: web
+    scheme: internal
+    ingressClass: "alb"
+    hostnames:
+      - test-ingresses.example.com
+    certificateArn: "arn:aws:acm:us-east-2:123456789:certificate/abcd1234-1a2b-3c4d-5e6f-987654abcd123"
+    omitDefaultPath: true

--- a/test/fixtures/ingresses/values-alb-group.yaml
+++ b/test/fixtures/ingresses/values-alb-group.yaml
@@ -23,6 +23,10 @@ ingresses:
     group:
       name: my-cool-group
       order: 10
+    # The carve member must not own the catch-all: the LBC orders Prefix
+    # paths ahead of ImplementationSpecific ones regardless of spec order,
+    # and within the group the lower order band wins.
+    omitDefaultPath: true
     extraPaths:
       - path: /api/*
         service:

--- a/test/fixtures/ingresses/values-alb-group.yaml
+++ b/test/fixtures/ingresses/values-alb-group.yaml
@@ -1,0 +1,48 @@
+global:
+  awsAccountId: "123456789"
+  image: docker.io/image:abcd1234
+  annotations:
+    provi.repository: https://github.com/example/repo
+    provi.slack: my-cool-team
+  labels:
+    team: cool-team
+
+# One hostname, one ALB: the app ingress carves its paths out ahead of a
+# static catch-all, the pattern proven on the REX-2033 preview prototype.
+ingresses:
+  app:
+    service:
+      port: 8080
+      name: web
+    scheme: internal
+    ingressClass: "alb"
+    hostnames:
+      - test-ingresses.example.com
+    certificateArn: "arn:aws:acm:us-east-2:123456789:certificate/abcd1234-1a2b-3c4d-5e6f-987654abcd123"
+    healthcheckPath: /healthz
+    group:
+      name: my-cool-group
+      order: 10
+    extraPaths:
+      - path: /api/*
+        service:
+          name: web
+          port: 8080
+      - path: /users/*
+        pathType: ImplementationSpecific
+        service:
+          name: web
+          port: 8080
+  static:
+    service:
+      port: 80
+      name: static-web
+    scheme: internal
+    ingressClass: "alb"
+    hostnames:
+      - test-ingresses.example.com
+    certificateArn: "arn:aws:acm:us-east-2:123456789:certificate/abcd1234-1a2b-3c4d-5e6f-987654abcd123"
+    healthcheckPath: /_healthz
+    group:
+      name: my-cool-group
+      order: 20

--- a/test/test_ingresses.bats
+++ b/test/test_ingresses.bats
@@ -195,3 +195,28 @@ teardown() {
                 port:
                   name: use-annotation"
 }
+
+# bats test_tags=tag:alb-group
+@test "alb-group: grouped ingresses share the group annotations and Name tag" {
+  run helm template -f test/fixtures/ingresses/values-alb-group.yaml test/fixtures/ingresses/
+  assert_output --partial 'alb.ingress.kubernetes.io/group.name: my-cool-group'
+  assert_output --partial 'alb.ingress.kubernetes.io/group.order: "10"'
+  assert_output --partial 'alb.ingress.kubernetes.io/group.order: "20"'
+  assert_output --partial 'alb.ingress.kubernetes.io/tags: Name=my-cool-group'
+  refute_output --partial 'alb.ingress.kubernetes.io/tags: Name=app-alb'
+  refute_output --partial 'alb.ingress.kubernetes.io/tags: Name=static-alb'
+}
+
+# bats test_tags=tag:alb-group
+@test "alb-group: extraPaths render before the default catch-all path" {
+  run helm template -f test/fixtures/ingresses/values-alb-group.yaml test/fixtures/ingresses/
+  assert_output --partial 'path: /api/*'
+  assert_output --partial 'path: /users/*'
+  assert_output --partial 'pathType: ImplementationSpecific'
+}
+
+# bats test_tags=tag:alb-group
+@test "alb-group: matches expected output" {
+  helm template -f test/fixtures/ingresses/values-alb-group.yaml test/fixtures/ingresses/ > "$TEST_TEMP_DIR/alb_group_output.yaml"
+  assert diff -ub test/expected_output/ingresses-alb-group.yaml "$TEST_TEMP_DIR/alb_group_output.yaml"
+}

--- a/test/test_ingresses.bats
+++ b/test/test_ingresses.bats
@@ -208,11 +208,28 @@ teardown() {
 }
 
 # bats test_tags=tag:alb-group
-@test "alb-group: extraPaths render before the default catch-all path" {
+@test "alb-group: the carve member renders only its extraPaths, the catch-all member owns /" {
   run helm template -f test/fixtures/ingresses/values-alb-group.yaml test/fixtures/ingresses/
   assert_output --partial 'path: /api/*'
   assert_output --partial 'path: /users/*'
   assert_output --partial 'pathType: ImplementationSpecific'
+  # exactly one "- path: /" across the group: the omitDefaultPath member must not
+  # emit the catch-all (a Prefix "/" outranks every ImplementationSpecific carve)
+  [ "$(echo "$output" | grep -c 'path: /$')" -eq 1 ]
+}
+
+# bats test_tags=tag:alb-group
+@test "alb-group: group.name is required when group is set" {
+  run helm template -f test/fixtures/ingresses/badvalues-alb-group-no-name.yaml test/fixtures/ingresses/
+  assert_failure
+  assert_output --partial 'You must specify group.name when group is set for ingress [dummy]'
+}
+
+# bats test_tags=tag:alb-group
+@test "alb-group: omitDefaultPath without extraPaths fails" {
+  run helm template -f test/fixtures/ingresses/badvalues-omitdefaultpath-no-extrapaths.yaml test/fixtures/ingresses/
+  assert_failure
+  assert_output --partial 'omitDefaultPath requires at least one extraPaths entry for ingress [dummy]'
 }
 
 # bats test_tags=tag:alb-group


### PR DESCRIPTION
## What

Two additive keys on `ingresses.<name>` in the common chart:

- **`group:`** (`name` required, `order` optional): emits `alb.ingress.kubernetes.io/group.name` / `group.order`, and makes grouped ingresses share `Name=<group.name>` as their ALB tag. Tags are group-level in the AWS Load Balancer Controller, so the chart's per-ingress `Name=<key>-alb` tag makes any two chart-rendered ingresses group-incompatible today (the controller fails the group build on the tag conflict).
- **`extraPaths:`** (list of `path`, optional `pathType` defaulting to `ImplementationSpecific`, `service.name`/`service.port`) plus **`omitDefaultPath: true`** for members that must not own the catch-all. Note the LBC (>= v2.4.3) orders rules by pathType (Exact, then Prefix longest-first, then ImplementationSpecific in manifest order), NOT spec order — so a Prefix `/` would shadow every carve. When extraPaths are present the default `/` therefore downgrades to `ImplementationSpecific` (still overridable via `pathType`), and the carve/catch-all group topology uses `omitDefaultPath` on the carving member, matching what was actually proven on the prototype (its carve ingress never owned `/`).

Omitting both renders byte-identical output to the current chart (regression-checked against the existing ingress fixtures).

## Why

[REX-2033](https://teamprovi.atlassian.net/browse/REX-2033) (marketplace SPA hosting cutover) needs a same-origin path split: static SPA origin on `/`, Rails keeping `/api`, `/cable`, Devise, and assets. Per the #talk-infrasec conversation (2026-08-10) the split lives in shared-ALB path rules. We proved the mechanism end to end on a garden preview env (login/CSRF/ActionCable through the split, 10-second rollback) — but only with hand-applied annotations, because of the tag conflict and the single-`/`-path limitation this PR fixes. Full findings are on the REX-2033 ticket; the live demo env is Provi-Engineering/provi#15095.

The fixture (`values-alb-group.yaml`) models the exact proven topology: an app ingress carving `/api/*` and `/users/*` at order 10, a static catch-all at order 20, one hostname.

## Notes for review

- Grouped members automatically inherit the chart's `listen-ports`/`ssl-redirect` annotations, which avoids the silent zero-rules failure mode we hit with a hand-applied member (rules landing on the ssl-redirect-emptied :80 listener while the ingress reports SuccessfullyReconciled).
- Group names are cluster-global: ingresses in different namespaces with the same `group.name` join one ALB. Worth a callout in whatever docs accompany this.
- Local bats: all 28 ingress tests pass (5 new, including negative cases for `group` without `name` and `omitDefaultPath` without `extraPaths`). 8 pre-existing failures in unrelated suites (autoscaler/CES/deployments/jobs/podspec) reproduce identically on clean master under helm v4 locally. Heads-up: this repo has no PR-stage CI (the release workflow tests on push to main only), so the local ingress-suite run is the pre-merge signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[REX-2033]: https://teamprovi.atlassian.net/browse/REX-2033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

